### PR TITLE
[Fix] Change EditorResponse.data to string

### DIFF
--- a/src/controllers/DocumentController.ts
+++ b/src/controllers/DocumentController.ts
@@ -53,7 +53,7 @@ export class DocumentController {
         let DOWNLOAD_URL: string | null = null;
 
         const documentResponse = await this.getCurrentDocumentState();
-        currentDocument = documentResponse.data ? String(documentResponse.data) : null;
+        currentDocument = documentResponse.data ? JSON.parse(documentResponse.data) : null;
         const FETCH_URL = getFetchURL(format, layoutId);
         try {
             const response = await fetch(FETCH_URL, {

--- a/types/CommonTypes.ts
+++ b/types/CommonTypes.ts
@@ -23,7 +23,7 @@ export type ConfigType = {
 export type EditorResponse = {
     success: boolean;
     status: number;
-    data?: unknown;
+    data?: string;
     error?: string;
 };
 export interface EditorAPI extends CallSender {


### PR DESCRIPTION
This PR changes the editor-response data to string type

## Related tickets

-   [WRS-495](https://support.chili-publish.com/projects/WRS/issues/WRS-495)