### PR TITLE
[Fix] Adjust interface used for moving position of a list of variables

### DIFF
--- a/src/controllers/VariableController.ts
+++ b/src/controllers/VariableController.ts
@@ -1,5 +1,5 @@
 import { EditorAPI } from '../../types/CommonTypes';
-import { MoveVariable, VariableType } from '../../types/VariableTypes';
+import { VariableMoves, VariableType } from '../../types/VariableTypes';
 
 /**
  * The VariableController is responsible for all communication regarding the variables.
@@ -150,7 +150,7 @@ export class VariableController {
      * This method changes positions of variables
      * @returns
      */
-    moveVariables = async (movedVariables: MoveVariable[]) => {
+    moveVariables = async (movedVariables: VariableMoves) => {
         const res = await this.#editorAPI;
         return res.moveVariables(movedVariables);
     };

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,7 @@ export { VariableType } from '../types/VariableTypes';
 
 export type { LayoutPropertiesType, FrameProperties, LayoutWithFrameProperties } from '../types/LayoutTypes';
 export type { FrameLayoutType, FrameType, Frame, TextFrame, ImageFrame } from '../types/FrameTypes';
-export type { Variable, MoveVariable } from '../types/VariableTypes';
+export type { Variable, VariableMoves } from '../types/VariableTypes';
 
 export type { DocumentError } from '../types/DocumentTypes';
 export type {

--- a/src/tests/controllers/VariableController.test.ts
+++ b/src/tests/controllers/VariableController.test.ts
@@ -98,7 +98,7 @@ describe('Variable controller', () => {
     });
 
     it('moveVariables', async () => {
-        await mockedSDK.variable.moveVariables([{ id: '1', parent: '6', order: 0 }]);
+        await mockedSDK.variable.moveVariables({ moves: ['1'], parent: '6', order: 0 });
         expect(mockedSDK.editorAPI.moveVariables).toHaveBeenCalledTimes(1);
         expect(mockedSDK.editorAPI.moveVariables).toHaveBeenCalledWith([{ id: '1', parent: '6', order: 0 }]);
     });

--- a/src/tests/controllers/VariableController.test.ts
+++ b/src/tests/controllers/VariableController.test.ts
@@ -100,7 +100,7 @@ describe('Variable controller', () => {
     it('moveVariables', async () => {
         await mockedSDK.variable.moveVariables({ moves: ['1'], parent: '6', order: 0 });
         expect(mockedSDK.editorAPI.moveVariables).toHaveBeenCalledTimes(1);
-        expect(mockedSDK.editorAPI.moveVariables).toHaveBeenCalledWith([{ id: '1', parent: '6', order: 0 }]);
+        expect(mockedSDK.editorAPI.moveVariables).toHaveBeenCalledWith({ moves: ['1'], parent: '6', order: 0 });
     });
 
     it('set isHidden', async () => {

--- a/types/VariableTypes.ts
+++ b/types/VariableTypes.ts
@@ -16,8 +16,8 @@ export type Variable  = {
     defaultValue?: string;
 }
 
-export type MoveVariable = {
-    id: string;
-    parent: string;
+export type VariableMoves = {
+    moves: string[];
     order: number;
+    parent: string;
 }


### PR DESCRIPTION
This PR adjusts interface used for moving position of a list of variables

## Related tickets

-   [WRS-506](https://support.chili-publish.com/projects/WRS/issues/WRS-506)

## Screenshots
