### PR TITLE
[Fix] Fix download document issue

### DIFF
--- a/src/controllers/DocumentController.ts
+++ b/src/controllers/DocumentController.ts
@@ -55,7 +55,8 @@ export class DocumentController {
         let DOWNLOAD_URL: string | null = null;
 
         const documentResponse = await this.getCurrentDocumentState();
-        currentDocument = documentResponse.data ? JSON.parse(documentResponse.data) : null;
+        console.log(documentResponse, 'DMDMDMDMDMDMDMMDM');
+        currentDocument = documentResponse.data ?? null;
         const FETCH_URL = getFetchURL(format, layoutId);
         try {
             const response = await fetch(FETCH_URL, {

--- a/src/controllers/DocumentController.ts
+++ b/src/controllers/DocumentController.ts
@@ -55,7 +55,6 @@ export class DocumentController {
         let DOWNLOAD_URL: string | null = null;
 
         const documentResponse = await this.getCurrentDocumentState();
-        console.log(documentResponse, 'DMDMDMDMDMDMDMMDM');
         currentDocument = documentResponse.data ?? null;
         const FETCH_URL = getFetchURL(format, layoutId);
         try {


### PR DESCRIPTION
This PR fixes download document issue by removing the JSON.parse operation because no need to parse returned object anymore.

## Related tickets

-   [WRS-544](https://support.chili-publish.com/projects/WRS/issues/WRS-544)

## Screenshots
