### PR TITLE
[Fix] Debug controller method names

### DIFF
--- a/src/controllers/DebugController.ts
+++ b/src/controllers/DebugController.ts
@@ -36,20 +36,20 @@ export class DebugController {
     };
 
     /**
-     * This method enables the debug panel
+     * This method enables the debugging
      * @returns
      */
-    enableDebugPanel = async () => {
+    enableDebug = async () => {
         const res = await this.#editorAPI;
-        return res.enableDebugPanel();
+        return res.enableDebug();
     };
 
     /**
-     * This method disables the debug panel
+     * This method disables the debugging
      * @returns
      */
-    disableDebugPanel = async () => {
+    disableDebug = async () => {
         const res = await this.#editorAPI;
-        return res.disableDebugPanel();
+        return res.disableDebug();
     };
 }

--- a/src/tests/__mocks__/FrameProperties.ts
+++ b/src/tests/__mocks__/FrameProperties.ts
@@ -70,8 +70,8 @@ export const mockGetAnimationByFrameId = jest.fn().mockResolvedValue({ success: 
 export const mockGetAnimationsByLayoutId = jest.fn().mockResolvedValue({ success: true, status: 0 });
 export const mockGetLogs = jest.fn().mockResolvedValue({ success: true, status: 0 });
 export const mockToggleDebugPanel = jest.fn().mockResolvedValue({ success: true, status: 0 });
-export const mockEnableDebugPanel = jest.fn().mockResolvedValue({ success: true, status: 0 });
-export const mockDisableDebugPanel = jest.fn().mockResolvedValue({ success: true, status: 0 });
+export const mockEnableDebug = jest.fn().mockResolvedValue({ success: true, status: 0 });
+export const mockDisableDebug = jest.fn().mockResolvedValue({ success: true, status: 0 });
 export const mockUndo = jest.fn().mockResolvedValue({ success: true, status: 0 });
 export const mockRedo = jest.fn().mockResolvedValue({ success: true, status: 0 });
 
@@ -147,8 +147,8 @@ const MockEditorAPI = {
     getPages: mockGetPages,
     getPageById: mockGetPageById,
     getLogs: mockGetLogs,
-    enableDebugPanel: mockEnableDebugPanel,
-    disableDebugPanel: mockDisableDebugPanel,
+    enableDebug: mockEnableDebug,
+    disableDebug: mockDisableDebug,
     toggleDebugPanel: mockToggleDebugPanel,
     undo: mockUndo,
     redo: mockRedo,

--- a/src/tests/controllers/DebugController.test.ts
+++ b/src/tests/controllers/DebugController.test.ts
@@ -7,8 +7,8 @@ beforeEach(() => {
     mockedDebugProperties = new DebugController(MockEditorAPI);
     jest.spyOn(mockedDebugProperties, 'getLogs');
     jest.spyOn(mockedDebugProperties, 'toggleDebugPanel');
-    jest.spyOn(mockedDebugProperties, 'enableDebugPanel');
-    jest.spyOn(mockedDebugProperties, 'disableDebugPanel');
+    jest.spyOn(mockedDebugProperties, 'enableDebug');
+    jest.spyOn(mockedDebugProperties, 'disableDebug');
 });
 
 afterAll(() => {
@@ -20,9 +20,9 @@ describe('DebugProperties', () => {
         expect(mockedDebugProperties.getLogs).toHaveBeenCalledTimes(1);
         mockedDebugProperties.toggleDebugPanel();
         expect(mockedDebugProperties.toggleDebugPanel).toHaveBeenCalledTimes(1);
-        mockedDebugProperties.enableDebugPanel();
-        expect(mockedDebugProperties.enableDebugPanel).toHaveBeenCalledTimes(1);
-        mockedDebugProperties.disableDebugPanel();
-        expect(mockedDebugProperties.disableDebugPanel).toHaveBeenCalledTimes(1);
+        mockedDebugProperties.enableDebug();
+        expect(mockedDebugProperties.enableDebug).toHaveBeenCalledTimes(1);
+        mockedDebugProperties.disableDebug();
+        expect(mockedDebugProperties.disableDebug).toHaveBeenCalledTimes(1);
     });
 });


### PR DESCRIPTION
This PR updates the names of debug controller methods for fixing an wrong naming error.

## Related tickets


## Screenshots
