### PR TITLE
[Feature] Enable onSelectedLayoutFramesChanged method

### DIFF
--- a/src/controllers/SubscriberController.ts
+++ b/src/controllers/SubscriberController.ts
@@ -106,4 +106,13 @@ export class SubscriberController {
         const callBack = this.config.onUndoStackStateChanged;
         callBack(JSON.parse(undoState));
     };
+
+    /**
+     * Listener on the state of the currently selected layout's frames, if this changes, this listener will get triggered with the updates
+     * @param frames Stringified object of Frames
+     */
+    onSelectedLayoutFramesChanged = (frames: string) => {
+        const callBack = this.config.onSelectedLayoutFramesChanged;
+        callBack(JSON.parse(frames));
+    };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,7 +39,7 @@ export type {
     AnimationPlaybackType,
     BasicAnimationsType,
 } from '../types/AnimationTypes';
-export type { ConfigType, InitialStateType, PageType, EditorResponse } from '../types/CommonTypes';
+export type { ConfigType, InitialStateType, PageType, EditorResponse, SelectedLayoutFrame } from '../types/CommonTypes';
 
 let connection: Connection;
 
@@ -107,6 +107,7 @@ export class SDK {
                 onVariableListChanged: this.subscriber.onVariableListChanged,
                 onSelectedToolChanged: this.subscriber.onSelectedToolChanged,
                 onUndoStateChanged: this.subscriber.onUndoStateChanged,
+                onSelectedLayoutFramesChanged: this.subscriber.onSelectedLayoutFramesChanged,
             },
             this.setConnection,
             this.config.editorId,

--- a/src/interactions/connector.ts
+++ b/src/interactions/connector.ts
@@ -52,6 +52,7 @@ interface ConfigParameterTypes {
     onVariableListChanged: (state: string) => void;
     onSelectedToolChanged: (state: string) => void;
     onUndoStateChanged: (state: string) => void;
+    onSelectedLayoutFramesChanged: (state: string) => void;
 }
 
 const Connect = (
@@ -100,6 +101,7 @@ const Connect = (
                 selectedToolChanged: params.onSelectedToolChanged,
                 variableListChanged: params.onVariableListChanged,
                 undoStackStateChanged: params.onUndoStateChanged,
+                selectedLayoutFramesChanged: params.onSelectedLayoutFramesChanged,
             },
         }),
     );

--- a/src/tests/__mocks__/config.ts
+++ b/src/tests/__mocks__/config.ts
@@ -14,5 +14,6 @@ const mockConfig: ConfigType = {
     onVariableListChanged: defaultMockReturn,
     onSelectedToolChanged: defaultMockReturn,
     onUndoStackStateChanged: jest.fn().mockResolvedValue({ success: true, status: 0 }),
+    onSelectedLayoutFramesChanged: defaultMockReturn,
 };
 export default mockConfig;

--- a/src/tests/controllers/SubscriberContoller.test.ts
+++ b/src/tests/controllers/SubscriberContoller.test.ts
@@ -27,6 +27,7 @@ beforeEach(() => {
     jest.spyOn(mockedSubscribers, 'onSelectedToolChanged');
     jest.spyOn(mockedSubscribers, 'onAnimationPlaybackChanged');
     jest.spyOn(mockedSubscribers, 'onUndoStateChanged');
+    jest.spyOn(mockedSubscribers, 'onSelectedLayoutFramesChanged');
 });
 
 afterEach(() => {
@@ -64,6 +65,9 @@ describe('Subscriber methods', () => {
         mockedSubscribers.onVariableListChanged('[{"id":"1","type":"group"}]');
         expect(mockedSDK.config.onVariableListChanged).toHaveBeenCalled();
         expect(mockedSDK.config.onVariableListChanged).toHaveBeenCalledWith([{ id: '1', type: VariableType.group }]);
+
+        mockedSubscribers.onSelectedLayoutFramesChanged('5');
+        expect(mockedSDK.config.onSelectedLayoutFramesChanged).toHaveBeenCalledTimes(9);
     });
 
     it('Should call trigger the SelectedToolChanged subscriber when triggered', () => {

--- a/src/tests/interactions/connector.test.tsx
+++ b/src/tests/interactions/connector.test.tsx
@@ -21,6 +21,7 @@ describe.skip('Editor Link Validator', () => {
                 onVariableListChanged: () => null,
                 onSelectedToolChanged: () => null,
                 onUndoStateChanged: () => null,
+                onSelectedLayoutFramesChanged: () => null,
             },
             () => null,
         );
@@ -49,6 +50,7 @@ describe.skip('Editor Link Validator', () => {
                 onVariableListChanged: () => null,
                 onSelectedToolChanged: () => null,
                 onUndoStateChanged: () => null,
+                onSelectedLayoutFramesChanged: () => null,
             },
             () => null,
         );
@@ -76,6 +78,7 @@ describe.skip('Editor Link Validator', () => {
                 onVariableListChanged: () => null,
                 onSelectedToolChanged: () => null,
                 onUndoStateChanged: () => null,
+                onSelectedLayoutFramesChanged: () => null,
             },
             () => null,
         );

--- a/types/CommonTypes.ts
+++ b/types/CommonTypes.ts
@@ -5,7 +5,7 @@ import { FrameLayoutType } from './FrameTypes';
 import type { FrameType } from './FrameTypes';
 import { Variable } from './VariableTypes';
 import { ToolType } from '../src/utils/enums';
-import {UndoState} from "./DocumentTypes";
+import { UndoState } from './DocumentTypes';
 
 export type ConfigType = {
     onStateChanged: (state: InitialStateType) => void;
@@ -20,6 +20,7 @@ export type ConfigType = {
     onVariableListChanged: (variableList: Variable[]) => void;
     onSelectedToolChanged: (tool: ToolType) => void;
     onUndoStackStateChanged: (undoStackState: UndoState) => void;
+    onSelectedLayoutFramesChanged: (frames: SelectedLayoutFrame[]) => void;
 };
 
 export type EditorResponse = {
@@ -50,4 +51,10 @@ export type InitialStateType = {
 export interface PropertyState<T> {
     value: T;
     isOverride: boolean;
+}
+
+export interface SelectedLayoutFrame {
+    frameId: number;
+    frameName: string;
+    included: boolean;
 }


### PR DESCRIPTION
This PR adds a new editor method for listening selected layout's frames changes.

## Related tickets

-   [WRS-725](https://support.chili-publish.com/projects/WRS/issues/WRS-725)

## Screenshots
