### PR TITLE
[Fix] Pass animation data to setFrameAnimation method

### DIFF
--- a/src/controllers/AnimationController.ts
+++ b/src/controllers/AnimationController.ts
@@ -63,7 +63,7 @@ export class AnimationController {
     setFrameAnimation = async (animation: FrameAnimationPropertiesType) => {
         const res = await this.#editorAPI;
         return res
-            .setFrameAnimation()
+            .setFrameAnimation(JSON.stringify(animation))
             .then((result) =>
                 getEditorResponseData<FrameAnimationPropertiesType>({ ...result, data: JSON.stringify(animation) }),
             );

--- a/src/tests/controllers/AnimationController.test.ts
+++ b/src/tests/controllers/AnimationController.test.ts
@@ -45,6 +45,7 @@ describe('Animation methods', () => {
 
         await mockedSDK.animation.setFrameAnimation(mockedAnimation.animation);
         expect(mockedSDK.editorAPI.setFrameAnimation).toHaveBeenCalledTimes(1);
+        expect(mockedSDK.editorAPI.setFrameAnimation).toHaveBeenCalledWith(JSON.stringify(mockedAnimation.animation));
 
         await mockedSDK.animation.playAnimation();
         expect(mockedSDK.editorAPI.playAnimation).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
This PR sends missing data to setFrameAnimation call
