### PR TITLE
[Feature] Bump Editor Engine version

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -71,7 +71,7 @@ export { ColorType } from '../types/ColorStyleTypes';
 
 let connection: Connection;
 
-const FIXED_EDITOR_LINK = 'https://studio-cdn.chiligrafx.com/editor/0.0.6/web';
+const FIXED_EDITOR_LINK = 'https://studio-cdn.chiligrafx.com/editor/0.0.7/web';
 
 export class SDK {
     config: ConfigType;


### PR DESCRIPTION
This PR bumps the editor engine version to 0.0.7 which includes, amongst others, Media Connectors, Configuration Api and default empty documents.