### PR TITLE
[Fix] husky postinstall breaks workspace builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,8 +59,7 @@
         "format-staged": "pretty-quick --staged",
         "cover": "jest --coverage",
         "make-badges": "node createCoverageBadge",
-        "validate-licenses": "node validate_licenses.js",
-        "postinstall": "node ./node_modules/husky/lib/bin install"
+        "validate-licenses": "node validate_licenses.js"
     },
     "husky": {
         "hooks": {


### PR DESCRIPTION
This PR fixes a build issue when taking dependency on editor-sdk

## Related tickets


## Screenshots
