### PR TITLE
[Fix] Correct text font family key used for update

### DIFF
--- a/types/TextStyleTypes.ts
+++ b/types/TextStyleTypes.ts
@@ -77,7 +77,7 @@ export enum SelectedTextStyleSections {
 export enum SelectedTextStyles {
     PARAGRAPH = 'paragraph',
     CHARACTER = 'character',
-    FONT_FAMILY = 'fontFamily',
+    FONT_FAMILY = 'fontKey',
     FONT_STYLE = 'fontStyle',
     FONT_SIZE = 'fontSize',
     LETTER_SPACING = 'letterSpacing',


### PR DESCRIPTION
This PR corrects text font family key used for update

## Related tickets

-   [WRS-863](https://support.chili-publish.com/projects/WRS/issues/WRS-863)

## Screenshots
