### PR TITLE
[Fix] Bump Engine version for release 0.0.9

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -86,7 +86,7 @@ export { WellKnownConfigurationKeys } from '../types/ConfigurationTypes';
 
 let connection: Connection;
 
-const FIXED_EDITOR_LINK = 'https://studio-cdn.chiligrafx.com/editor/0.0.7/web';
+const FIXED_EDITOR_LINK = 'https://studio-cdn.chiligrafx.com/editor/0.0.9/web';
 
 export class SDK {
     config: ConfigType;


### PR DESCRIPTION
This PR bumps the editor-engine version to 0.0.9
