### PR TITLE
[Feature] Add authentication methods

### DIFF
--- a/src/controllers/MediaConnectorController.ts
+++ b/src/controllers/MediaConnectorController.ts
@@ -179,9 +179,12 @@ export class ConnectorAuthenticationController {
     }
 
     /**
-     * This method sets the token for the 'chili' authentication type.
+     * This method sets the CHILI GraFx Access Token in the Authentication HTTP header for the 'chili' authentication type.
+     * The CHILI Token will be used in every connector fetch call.
+     * Gives access to the CHILI environment API.
+     * Can only be used after a connector has been registered.
      * @param connectorId unique Id of the media connector
-     * @param token token for the chili authentication
+     * @param token token for the CHILI authentication
      */
     setChiliToken = async (connectorId: string, token: string) => {
         const res = await this.#editorAPI;
@@ -190,7 +193,9 @@ export class ConnectorAuthenticationController {
     }
 
     /**
-     * This method sets the http headers for the 'staticKey' authentication type.
+     * This method sets the HTTP headers for the 'staticKey' authentication type.
+     * Those authentication headers will be used in every connector fetch call.
+     * Can only be used after a connector has been registered.
      * @param connectorId unique Id of the media connector
      * @param headerName name of the header
      * @param headerValue value of the header

--- a/src/controllers/MediaConnectorController.ts
+++ b/src/controllers/MediaConnectorController.ts
@@ -180,8 +180,7 @@ export class ConnectorAuthenticationController {
 
     /**
      * This method sets the CHILI GraFx Access Token in the Authentication HTTP header for the 'chili' authentication type.
-     * The CHILI Token will be used in every connector fetch call.
-     * Gives access to the CHILI environment API.
+     * The CHILI Token will be used to authenticate every grafx-media connector http call.
      * Can only be used after a connector has been registered.
      * @param connectorId unique Id of the media connector
      * @param token token for the CHILI authentication
@@ -194,7 +193,7 @@ export class ConnectorAuthenticationController {
 
     /**
      * This method sets the HTTP headers for the 'staticKey' authentication type.
-     * Those authentication headers will be used in every connector fetch call.
+     * These additional headers will be added to all connector http calls.
      * Can only be used after a connector has been registered.
      * @param connectorId unique Id of the media connector
      * @param headerName name of the header

--- a/src/controllers/MediaConnectorController.ts
+++ b/src/controllers/MediaConnectorController.ts
@@ -28,6 +28,7 @@ export class MediaConnectorController {
      */
     #editorAPI: EditorAPI;
     #blobAPI: EditorRawAPI;
+    authentication: ConnectorAuthenticationController;
 
     /**
      * @ignore
@@ -35,6 +36,7 @@ export class MediaConnectorController {
     constructor(editorAPI: EditorAPI) {
         this.#editorAPI = editorAPI;
         this.#blobAPI = editorAPI as CallSender as EditorRawAPI;
+        this.authentication = new ConnectorAuthenticationController(editorAPI);
     }
 
     /**
@@ -158,3 +160,45 @@ export class MediaConnectorController {
         if (deprecatedType === DeprecatedMediaType.collection) return MediaType.collection;
     };
 }
+
+/**
+ * The ConnectorAuthenticationController is responsible for authenticating regarding media connectors.
+ * Methods inside this controller can be called by `window.SDK.mediaConnector.authentication.{method-name}`
+ */
+export class ConnectorAuthenticationController {
+    /**
+     * @ignore
+     */
+    #editorAPI: EditorAPI;
+
+    /**
+     * @ignore
+     */
+    constructor(editorAPI: EditorAPI) {
+        this.#editorAPI = editorAPI;
+    }
+
+    /**
+     * This method sets the token for the 'chili' authentication type.
+     * @param connectorId unique Id of the media connector
+     * @param token token for the chili authentication
+     */
+    setChiliToken = async (connectorId: string, token: string) => {
+        const res = await this.#editorAPI;
+        return res.connectorAuthenticationSetChiliToken(connectorId, token)
+            .then((result) => getEditorResponseData<null>(result));
+    }
+
+    /**
+     * This method sets the http headers for the 'staticKey' authentication type.
+     * @param connectorId unique Id of the media connector
+     * @param headerName name of the header
+     * @param headerValue value of the header
+     */
+    setHttpHeader = async (connectorId: string, headerName: string, headerValue: string) => {
+        const res = await this.#editorAPI;
+        return res.connectorAuthenticationSetHttpHeader(connectorId, headerName, headerValue)
+            .then((result) => getEditorResponseData<null>(result));
+    }
+}
+

--- a/src/tests/__mocks__/MockEditorAPI.ts
+++ b/src/tests/__mocks__/MockEditorAPI.ts
@@ -101,6 +101,8 @@ export const mockMediaConnectorUpload = jest.fn().mockResolvedValue({ success: t
 export const mockMediaConnectorGetCapabilities = jest.fn().mockResolvedValue({ success: true, status: 0 });
 export const mockMediaConnectorGetQueryOptions = jest.fn().mockResolvedValue({ success: true, status: 0 });
 export const mockMediaConnectorGetDownloadOptions = jest.fn().mockResolvedValue({ success: true, status: 0 });
+export const mockConnectorAuthenticationSetChiliToken = jest.fn().mockResolvedValue({ success: true, status: 0 });
+export const mockConnectorAuthenticationSetHttpHeader = jest.fn().mockResolvedValue({ success: true, status: 0 });
 export const mockSetConfigValue = jest.fn().mockResolvedValue({ success: true, status: 0 });
 export const mockGetConfigValue = jest.fn().mockResolvedValue({ success: true, status: 0 });
 
@@ -209,6 +211,8 @@ const MockEditorAPI = {
     mediaConnectorGetCapabilities: mockMediaConnectorGetCapabilities,
     mediaConnectorGetQueryOptions: mockMediaConnectorGetQueryOptions,
     mediaConnectorGetDownloadOptions: mockMediaConnectorGetDownloadOptions,
+    connectorAuthenticationSetChiliToken: mockConnectorAuthenticationSetChiliToken,
+    connectorAuthenticationSetHttpHeader: mockConnectorAuthenticationSetHttpHeader,
     getConfigValue: mockGetConfigValue,
     setConfigValue: mockSetConfigValue,
 };

--- a/src/tests/controllers/MediaConnectorController.test.ts
+++ b/src/tests/controllers/MediaConnectorController.test.ts
@@ -1,6 +1,6 @@
 import { SDK } from '../../index';
 import mockConfig from '../__mocks__/config';
-import { MediaConnectorController } from '../../controllers/MediaConnectorController';
+import { ConnectorAuthenticationController, MediaConnectorController } from '../../controllers/MediaConnectorController';
 import { DownloadType, SortBy, SortOrder } from '../../../types/MediaConnectorTypes';
 import mockChild from '../__mocks__/MockEditorAPI';
 
@@ -10,6 +10,7 @@ beforeEach(() => {
     mockedSDK = new SDK(mockConfig);
     mockedSDK.editorAPI = mockChild;
     mockedSDK.mediaConnector = new MediaConnectorController(mockChild);
+    mockedSDK.mediaConnector.authentication = new ConnectorAuthenticationController(mockChild);
     jest.spyOn(mockedSDK.mediaConnector, 'query');
     jest.spyOn(mockedSDK.mediaConnector, 'download');
     jest.spyOn(mockedSDK.mediaConnector, 'upload');
@@ -18,6 +19,8 @@ beforeEach(() => {
     jest.spyOn(mockedSDK.mediaConnector, 'getCapabilities');
     jest.spyOn(mockedSDK.mediaConnector, 'getQueryOptions');
     jest.spyOn(mockedSDK.mediaConnector, 'getDownloadOptions');
+    jest.spyOn(mockedSDK.mediaConnector.authentication, 'setChiliToken');
+    jest.spyOn(mockedSDK.mediaConnector.authentication, 'setHttpHeader');
 });
 
 afterEach(() => {
@@ -43,6 +46,9 @@ describe('MediaConnector methods', () => {
         };
         const context = { debug: 'true' };
         const blob = new Uint8Array([1, 2, 3]);
+        const token = 'myToken';
+        const headerName = 'headerName';
+        const headerValue = 'headerValue';
 
         await mockedSDK.mediaConnector.copy(connectorId, mediaId, 'newName');
         expect(mockedSDK.editorAPI.mediaConnectorCopy).toHaveBeenCalledTimes(1);
@@ -92,5 +98,13 @@ describe('MediaConnector methods', () => {
         await mockedSDK.mediaConnector.getDownloadOptions(connectorId);
         expect(mockedSDK.editorAPI.mediaConnectorGetDownloadOptions).toHaveBeenCalledTimes(1);
         expect(mockedSDK.editorAPI.mediaConnectorGetDownloadOptions).toHaveBeenLastCalledWith(connectorId);
+
+        await mockedSDK.mediaConnector.authentication.setChiliToken(connectorId, token);
+        expect(mockedSDK.editorAPI.connectorAuthenticationSetChiliToken).toHaveBeenCalledTimes(1);
+        expect(mockedSDK.editorAPI.connectorAuthenticationSetChiliToken).toHaveBeenCalledWith(connectorId, token);
+
+        await mockedSDK.mediaConnector.authentication.setHttpHeader(connectorId, headerName, headerValue);
+        expect(mockedSDK.editorAPI.connectorAuthenticationSetHttpHeader).toHaveBeenCalledTimes(1);
+        expect(mockedSDK.editorAPI.connectorAuthenticationSetHttpHeader).toHaveBeenCalledWith(connectorId, headerName, headerValue);
     });
 });


### PR DESCRIPTION
This PR adds the authentication methods

## Related tickets

-   [EDT-549](https://support.chili-publish.com/browse/EDT-549)

I'm using `connectorX` and not `mediaConnectorX` as we are now streamlining the naming (we have a bigger ticket for it).

Not sure a sub controller is the best structure here but we want the `SDK.connector.authentication.setChiliToken(id, token)` type of path. [Confluence](https://chilipublishintranet.atlassian.net/wiki/spaces/dev/pages/4054319145/Media+Connectors#Alpha---Epic)

