### PR TITLE
Fix: Add enum string values for connector Registration types

### DIFF
--- a/src/controllers/ConnectorController.ts
+++ b/src/controllers/ConnectorController.ts
@@ -1,0 +1,42 @@
+import { ConnectorRegistration } from '../../types/ConnectorTypes';
+import { EditorAPI } from '../../types/CommonTypes';
+import { getEditorResponseData } from '../utils/EditorResponseData';
+
+/**
+ * The ConnectorController manages lifetime of all available connectors, regardless of the type, in the
+ * document. Use it to add/remove connectors to a template, or set specific configuration.
+ *
+ * The way CHILI Studio handles different sources of resouces is called 'Connectors'. A Connectors is an
+ * implementation of a set of capabilities we need to interact with a certain external resource management system.
+ * In essence a connector is the combination of a Javascript snippet and some metadata. The Javascript snippet
+ * is loaded in the studio engine using a sandboxed Javascript execution engine (QuickJs). This allows us to
+ * execute the media connector both on web using webassembly and on the server side during e.g. animation output
+ * generation.
+ * This controller is an interface to the running connector instance inside the studio engine.
+ */
+export class ConnectorController {
+    /**
+     * @ignore
+     */
+    #editorAPI: EditorAPI;
+
+    /**
+     * @ignore
+     */
+    constructor(editorAPI: EditorAPI) {
+        this.#editorAPI = editorAPI;
+    }
+
+    /**
+     * Registers a new connector in the SDK. After successfull registration, depending
+     * on the connector type, the connector can be configured and used in the template
+     * Remember to add custom authentication information after registering the connector
+     * @param ConnectorRegistration registration object containing all details about the connector
+     */
+    registerConnector = async (registration: ConnectorRegistration) => {
+        const res = await this.#editorAPI;
+        return res
+            .mediaConnectorRegisterConnector(JSON.stringify(registration))
+            .then((result) => getEditorResponseData<null>(result));
+    };
+}

--- a/src/controllers/FrameController.ts
+++ b/src/controllers/FrameController.ts
@@ -1,7 +1,7 @@
 import type { EditorAPI } from '../../types/CommonTypes';
 import { getCalculatedValue } from '../utils/getCalculatedValue';
 import { getEditorResponseData } from '../utils/EditorResponseData';
-import { FrameLayoutType, FrameType } from '../../types/FrameTypes';
+import { FrameLayoutType, FrameType, FrameTypeEnum } from '../../types/FrameTypes';
 
 /**
  * The FrameController is responsible for all communication regarding Frames.
@@ -313,18 +313,32 @@ export class FrameController {
         const res = await this.#editorAPI;
         return res.removeFrame(frameId).then((result) => getEditorResponseData<null>(result));
     };
+    /**
+     * This method will add a new frame of 'frameType' to the template positioned on the requested
+     * coordinates.
+     * @param frameType The type of frame to create
+     * @param x X coordinate of the new frame within the template
+     * @param y Y coordinate of the new frame within the template
+     * @param width Width of the new frame within the template
+     * @param height Height of the new frame within the template
+     * @returns The newly created frame's ID
+     */
+    addFrame = async (frameType: FrameTypeEnum, x: number, y: number, width: number, height: number) => {
+        const res = await this.#editorAPI;
+        return res.addFrame(frameType, x, y, width, height).then((result) => getEditorResponseData<number>(result));
+    };
 
     /**
-     * This method will assign an image from the mediaConnector to the correct imageFrame
+     * This method will assign an image from a mediaConnector to the correct imageFrame
      * @param imageFrameId The ID of the imageFrame where an image needs to be assigned to
      * @param connectorId Unique Id of the media connector
-     * @param imageId Unique Id of the image that you want to assign to the imageFrame
+     * @param resourceId Unique Id of the asset that you want to assign to the imageFrame
      * @returns
      */
-    assignImageToFrame = async (imageFrameId: number, connectorId: string, imageId: string) => {
+    setImageFromConnector = async (imageFrameId: number, connectorId: string, resourceId: string) => {
         const res = await this.#editorAPI;
         return res
-            .assignImage(imageFrameId, connectorId, imageId)
+            .assignImage(imageFrameId, connectorId, resourceId)
             .then((result) => getEditorResponseData<null>(result));
     };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ import { ConfigurationController } from './controllers/ConfigurationController';
 import { MediaConnectorController } from './controllers/MediaConnectorController';
 import { WellKnownConfigurationKeys } from '../types/ConfigurationTypes';
 import packageInfo from '../package.json';
+import { ConnectorController } from './controllers/ConnectorController';
 
 export { FrameProperyNames, LayoutProperyNames, ToolType, DownloadFormats } from './utils/enums';
 
@@ -99,6 +100,7 @@ export class SDK {
 
     layout: LayoutController;
     frame: FrameController;
+    connector: ConnectorController;
     mediaConnector: MediaConnectorController;
     animation: AnimationController;
     document: DocumentController;
@@ -128,6 +130,7 @@ export class SDK {
 
         this.layout = new LayoutController(this.editorAPI);
         this.frame = new FrameController(this.editorAPI);
+        this.connector = new ConnectorController(this.editorAPI);
         this.mediaConnector = new MediaConnectorController(this.editorAPI);
         this.animation = new AnimationController(this.editorAPI);
         this.document = new DocumentController(this.editorAPI);
@@ -190,6 +193,7 @@ export class SDK {
         this.colorStyle = new ColorStyleController(this.editorAPI);
         this.paragraphStyle = new ParagraphStyleController(this.editorAPI);
         this.mediaConnector = new MediaConnectorController(this.editorAPI);
+        this.connector = new ConnectorController(this.editorAPI);
 
         // as soon as the editor loads, provide it with the SDK version
         // used to make it start. This enables engine compatibility checks

--- a/src/tests/__mocks__/MockEditorAPI.ts
+++ b/src/tests/__mocks__/MockEditorAPI.ts
@@ -103,6 +103,7 @@ export const mockMediaConnectorGetQueryOptions = jest.fn().mockResolvedValue({ s
 export const mockMediaConnectorGetDownloadOptions = jest.fn().mockResolvedValue({ success: true, status: 0 });
 export const mockSetConfigValue = jest.fn().mockResolvedValue({ success: true, status: 0 });
 export const mockGetConfigValue = jest.fn().mockResolvedValue({ success: true, status: 0 });
+export const mockMediaConnectorRegisterConnector = jest.fn().mockResolvedValue({ success: true, status: 0 });
 
 const MockEditorAPI = {
     addLayout: mockAddLayout,
@@ -211,6 +212,7 @@ const MockEditorAPI = {
     mediaConnectorGetDownloadOptions: mockMediaConnectorGetDownloadOptions,
     getConfigValue: mockGetConfigValue,
     setConfigValue: mockSetConfigValue,
+    mediaConnectorRegisterConnector: mockMediaConnectorRegisterConnector,
 };
 
 export default MockEditorAPI;

--- a/src/tests/controllers/ConnectorController.test.ts
+++ b/src/tests/controllers/ConnectorController.test.ts
@@ -1,0 +1,33 @@
+import { SDK } from '../../index';
+import mockConfig from '../__mocks__/config';
+import { ConnectorController } from '../../controllers/ConnectorController';
+import { ConnectorRegistrationSource, ConnectorType } from '../../../types/ConnectorTypes';
+import mockChild from '../__mocks__/MockEditorAPI';
+
+let mockedSDK: SDK;
+
+beforeEach(() => {
+    mockedSDK = new SDK(mockConfig);
+    mockedSDK.editorAPI = mockChild;
+    mockedSDK.connector = new ConnectorController(mockChild);
+    jest.spyOn(mockedSDK.connector, 'registerConnector');
+});
+
+afterEach(() => {
+    jest.restoreAllMocks();
+});
+describe('Connector methods', () => {
+    it('Should call  all of the connector functions of child successfully', async () => {
+        const registration = {
+            id: '',
+            name: '',
+            source: ConnectorRegistrationSource.url,
+            type: ConnectorType.media,
+            url: '',
+        };
+
+        await mockedSDK.connector.registerConnector(registration);
+        expect(mockedSDK.editorAPI.mediaConnectorRegisterConnector).toHaveBeenCalledTimes(1);
+        expect(mockedSDK.editorAPI.mediaConnectorRegisterConnector).toHaveBeenCalledWith(JSON.stringify(registration));
+    });
+});

--- a/types/ConnectorTypes.ts
+++ b/types/ConnectorTypes.ts
@@ -7,10 +7,10 @@ export type ConnectorRegistration = {
 }
 
 export enum ConnectorType {
-    media,
-    font
+    media = 'media',
+    font = 'font'
 }
 
 export enum ConnectorRegistrationSource {
-    url
+    url = 'url'
 }

--- a/types/ConnectorTypes.ts
+++ b/types/ConnectorTypes.ts
@@ -1,0 +1,16 @@
+export type ConnectorRegistration = {
+    id: string,
+    name: string,
+    type: ConnectorType,
+    source: ConnectorRegistrationSource,
+    url: string
+}
+
+export enum ConnectorType {
+    media,
+    font
+}
+
+export enum ConnectorRegistrationSource {
+    url
+}

--- a/types/FrameTypes.ts
+++ b/types/FrameTypes.ts
@@ -18,7 +18,7 @@ export type FrameLayoutType = {
 export type FrameType = {
     frameId: number;
     frameName: string;
-    frameType: 'image';
+    frameType: FrameTypeEnum;
     imageUrl: string;
     blendMode: string;
 };


### PR DESCRIPTION
This PR adds missing string values for enums:

* ConnectorType
* ConnectorRegistrationSource

## Related tickets

## Screenshots
