### PR TITLE
[Fix] Add missing fitMode property to Frame interface

### DIFF
--- a/types/FrameTypes.ts
+++ b/types/FrameTypes.ts
@@ -12,6 +12,7 @@ export type FrameLayoutType = {
     scaleX: PropertyState<number>;
     scaleY: PropertyState<number>;
     included: PropertyState<boolean>;
+    fitMode: PropertyState<FitMode>
 } | null;
 
 //Frame.image


### PR DESCRIPTION
This PR adds missing fitMode property to Frame interface

## Related tickets

-   [WRS-850](https://support.chili-publish.com/projects/WRS/issues/WRS-850)

## Screenshots
