### PR TITLE
[Fix] ConnectorRegistration cleanup

### DIFF
--- a/src/tests/controllers/ConnectorController.test.ts
+++ b/src/tests/controllers/ConnectorController.test.ts
@@ -20,9 +20,7 @@ describe('Connector methods', () => {
     it('Should call  all of the connector functions of child successfully', async () => {
         const registration = {
             id: '',
-            name: '',
             source: ConnectorRegistrationSource.url,
-            type: ConnectorType.media,
             url: '',
         };
 

--- a/types/ConnectorTypes.ts
+++ b/types/ConnectorTypes.ts
@@ -1,7 +1,5 @@
 export type ConnectorRegistration = {
     id: string,
-    name: string,
-    type: ConnectorType,
     source: ConnectorRegistrationSource,
     url: string
 }


### PR DESCRIPTION
This PR cleans up the `ConnectorRegistration` model

## Related tickets

-   [EDT-626](https://support.chili-publish.com/browse/EDT-626)

`name` & `type` has been removed from the connector model on flutter side because they were redundant with the definition model hence confusing.