### PR TITLE
[Fix] [Blocker] Move authentication controller to ConnectorController.ts

### DIFF
--- a/src/controllers/ConnectorController.ts
+++ b/src/controllers/ConnectorController.ts
@@ -19,6 +19,39 @@ export class ConnectorController {
      * @ignore
      */
     #editorAPI: EditorAPI;
+    authentication: ConnectorAuthenticationController;
+
+    /**
+     * @ignore
+     */
+    constructor(editorAPI: EditorAPI) {
+        this.#editorAPI = editorAPI;
+        this.authentication = new ConnectorAuthenticationController(editorAPI);
+    }
+
+    /**
+     * Registers a new connector in the SDK. After successfull registration, depending
+     * on the connector type, the connector can be configured and used in the template
+     * Remember to add custom authentication information after registering the connector
+     * @param registration registration object containing all details about the connector
+     */
+    registerConnector = async (registration: ConnectorRegistration) => {
+        const res = await this.#editorAPI;
+        return res
+            .mediaConnectorRegisterConnector(JSON.stringify(registration))
+            .then((result) => getEditorResponseData<null>(result));
+    };
+}
+
+/**
+ * The ConnectorAuthenticationController is responsible for authenticating regarding media connectors.
+ * Methods inside this controller can be called by `window.SDK.mediaConnector.authentication.{method-name}`
+ */
+export class ConnectorAuthenticationController {
+    /**
+     * @ignore
+     */
+    #editorAPI: EditorAPI;
 
     /**
      * @ignore
@@ -28,15 +61,31 @@ export class ConnectorController {
     }
 
     /**
-     * Registers a new connector in the SDK. After successfull registration, depending
-     * on the connector type, the connector can be configured and used in the template
-     * Remember to add custom authentication information after registering the connector
-     * @param ConnectorRegistration registration object containing all details about the connector
+     * This method sets the CHILI GraFx Access Token in the Authentication HTTP header for the 'chili' authentication type.
+     * The CHILI Token will be used to authenticate every grafx-media connector http call.
+     * Can only be used after a connector has been registered.
+     * @param connectorId unique Id of the media connector
+     * @param token token for the CHILI authentication
      */
-    registerConnector = async (registration: ConnectorRegistration) => {
+    setChiliToken = async (connectorId: string, token: string) => {
         const res = await this.#editorAPI;
         return res
-            .mediaConnectorRegisterConnector(JSON.stringify(registration))
+            .connectorAuthenticationSetChiliToken(connectorId, token)
+            .then((result) => getEditorResponseData<null>(result));
+    };
+
+    /**
+     * This method sets the HTTP headers for the 'staticKey' authentication type.
+     * These additional headers will be added to all connector http calls.
+     * Can only be used after a connector has been registered.
+     * @param connectorId unique Id of the media connector
+     * @param headerName name of the header
+     * @param headerValue value of the header
+     */
+    setHttpHeader = async (connectorId: string, headerName: string, headerValue: string) => {
+        const res = await this.#editorAPI;
+        return res
+            .connectorAuthenticationSetHttpHeader(connectorId, headerName, headerValue)
             .then((result) => getEditorResponseData<null>(result));
     };
 }

--- a/src/controllers/MediaConnectorController.ts
+++ b/src/controllers/MediaConnectorController.ts
@@ -28,7 +28,6 @@ export class MediaConnectorController {
      */
     #editorAPI: EditorAPI;
     #blobAPI: EditorRawAPI;
-    authentication: ConnectorAuthenticationController;
 
     /**
      * @ignore
@@ -36,7 +35,6 @@ export class MediaConnectorController {
     constructor(editorAPI: EditorAPI) {
         this.#editorAPI = editorAPI;
         this.#blobAPI = editorAPI as CallSender as EditorRawAPI;
-        this.authentication = new ConnectorAuthenticationController(editorAPI);
     }
 
     /**
@@ -160,49 +158,3 @@ export class MediaConnectorController {
         if (deprecatedType === DeprecatedMediaType.collection) return MediaType.collection;
     };
 }
-
-/**
- * The ConnectorAuthenticationController is responsible for authenticating regarding media connectors.
- * Methods inside this controller can be called by `window.SDK.mediaConnector.authentication.{method-name}`
- */
-export class ConnectorAuthenticationController {
-    /**
-     * @ignore
-     */
-    #editorAPI: EditorAPI;
-
-    /**
-     * @ignore
-     */
-    constructor(editorAPI: EditorAPI) {
-        this.#editorAPI = editorAPI;
-    }
-
-    /**
-     * This method sets the CHILI GraFx Access Token in the Authentication HTTP header for the 'chili' authentication type.
-     * The CHILI Token will be used to authenticate every grafx-media connector http call.
-     * Can only be used after a connector has been registered.
-     * @param connectorId unique Id of the media connector
-     * @param token token for the CHILI authentication
-     */
-    setChiliToken = async (connectorId: string, token: string) => {
-        const res = await this.#editorAPI;
-        return res.connectorAuthenticationSetChiliToken(connectorId, token)
-            .then((result) => getEditorResponseData<null>(result));
-    }
-
-    /**
-     * This method sets the HTTP headers for the 'staticKey' authentication type.
-     * These additional headers will be added to all connector http calls.
-     * Can only be used after a connector has been registered.
-     * @param connectorId unique Id of the media connector
-     * @param headerName name of the header
-     * @param headerValue value of the header
-     */
-    setHttpHeader = async (connectorId: string, headerName: string, headerValue: string) => {
-        const res = await this.#editorAPI;
-        return res.connectorAuthenticationSetHttpHeader(connectorId, headerName, headerValue)
-            .then((result) => getEditorResponseData<null>(result));
-    }
-}
-

--- a/src/tests/controllers/ConnectorController.test.ts
+++ b/src/tests/controllers/ConnectorController.test.ts
@@ -1,6 +1,6 @@
 import { SDK } from '../../index';
 import mockConfig from '../__mocks__/config';
-import { ConnectorController } from '../../controllers/ConnectorController';
+import { ConnectorAuthenticationController, ConnectorController } from '../../controllers/ConnectorController';
 import { ConnectorRegistrationSource } from '../../../types/ConnectorTypes';
 import mockChild from '../__mocks__/MockEditorAPI';
 
@@ -10,7 +10,10 @@ beforeEach(() => {
     mockedSDK = new SDK(mockConfig);
     mockedSDK.editorAPI = mockChild;
     mockedSDK.connector = new ConnectorController(mockChild);
+    mockedSDK.connector.authentication = new ConnectorAuthenticationController(mockChild);
     jest.spyOn(mockedSDK.connector, 'registerConnector');
+    jest.spyOn(mockedSDK.connector.authentication, 'setChiliToken');
+    jest.spyOn(mockedSDK.connector.authentication, 'setHttpHeader');
 });
 
 afterEach(() => {
@@ -23,9 +26,25 @@ describe('Connector methods', () => {
             source: ConnectorRegistrationSource.url,
             url: '',
         };
+        const connectorId = 'dam';
+        const token = 'myToken';
+        const headerName = 'headerName';
+        const headerValue = 'headerValue';
 
         await mockedSDK.connector.registerConnector(registration);
         expect(mockedSDK.editorAPI.mediaConnectorRegisterConnector).toHaveBeenCalledTimes(1);
         expect(mockedSDK.editorAPI.mediaConnectorRegisterConnector).toHaveBeenCalledWith(JSON.stringify(registration));
+
+        await mockedSDK.connector.authentication.setChiliToken(connectorId, token);
+        expect(mockedSDK.editorAPI.connectorAuthenticationSetChiliToken).toHaveBeenCalledTimes(1);
+        expect(mockedSDK.editorAPI.connectorAuthenticationSetChiliToken).toHaveBeenCalledWith(connectorId, token);
+
+        await mockedSDK.connector.authentication.setHttpHeader(connectorId, headerName, headerValue);
+        expect(mockedSDK.editorAPI.connectorAuthenticationSetHttpHeader).toHaveBeenCalledTimes(1);
+        expect(mockedSDK.editorAPI.connectorAuthenticationSetHttpHeader).toHaveBeenCalledWith(
+            connectorId,
+            headerName,
+            headerValue,
+        );
     });
 });

--- a/src/tests/controllers/MediaConnectorController.test.ts
+++ b/src/tests/controllers/MediaConnectorController.test.ts
@@ -1,6 +1,6 @@
 import { SDK } from '../../index';
 import mockConfig from '../__mocks__/config';
-import { ConnectorAuthenticationController, MediaConnectorController } from '../../controllers/MediaConnectorController';
+import { MediaConnectorController } from '../../controllers/MediaConnectorController';
 import { DownloadType, SortBy, SortOrder } from '../../../types/MediaConnectorTypes';
 import mockChild from '../__mocks__/MockEditorAPI';
 
@@ -10,7 +10,6 @@ beforeEach(() => {
     mockedSDK = new SDK(mockConfig);
     mockedSDK.editorAPI = mockChild;
     mockedSDK.mediaConnector = new MediaConnectorController(mockChild);
-    mockedSDK.mediaConnector.authentication = new ConnectorAuthenticationController(mockChild);
     jest.spyOn(mockedSDK.mediaConnector, 'query');
     jest.spyOn(mockedSDK.mediaConnector, 'download');
     jest.spyOn(mockedSDK.mediaConnector, 'upload');
@@ -19,8 +18,6 @@ beforeEach(() => {
     jest.spyOn(mockedSDK.mediaConnector, 'getCapabilities');
     jest.spyOn(mockedSDK.mediaConnector, 'getQueryOptions');
     jest.spyOn(mockedSDK.mediaConnector, 'getDownloadOptions');
-    jest.spyOn(mockedSDK.mediaConnector.authentication, 'setChiliToken');
-    jest.spyOn(mockedSDK.mediaConnector.authentication, 'setHttpHeader');
 });
 
 afterEach(() => {
@@ -46,9 +43,6 @@ describe('MediaConnector methods', () => {
         };
         const context = { debug: 'true' };
         const blob = new Uint8Array([1, 2, 3]);
-        const token = 'myToken';
-        const headerName = 'headerName';
-        const headerValue = 'headerValue';
 
         await mockedSDK.mediaConnector.copy(connectorId, mediaId, 'newName');
         expect(mockedSDK.editorAPI.mediaConnectorCopy).toHaveBeenCalledTimes(1);
@@ -98,13 +92,5 @@ describe('MediaConnector methods', () => {
         await mockedSDK.mediaConnector.getDownloadOptions(connectorId);
         expect(mockedSDK.editorAPI.mediaConnectorGetDownloadOptions).toHaveBeenCalledTimes(1);
         expect(mockedSDK.editorAPI.mediaConnectorGetDownloadOptions).toHaveBeenLastCalledWith(connectorId);
-
-        await mockedSDK.mediaConnector.authentication.setChiliToken(connectorId, token);
-        expect(mockedSDK.editorAPI.connectorAuthenticationSetChiliToken).toHaveBeenCalledTimes(1);
-        expect(mockedSDK.editorAPI.connectorAuthenticationSetChiliToken).toHaveBeenCalledWith(connectorId, token);
-
-        await mockedSDK.mediaConnector.authentication.setHttpHeader(connectorId, headerName, headerValue);
-        expect(mockedSDK.editorAPI.connectorAuthenticationSetHttpHeader).toHaveBeenCalledTimes(1);
-        expect(mockedSDK.editorAPI.connectorAuthenticationSetHttpHeader).toHaveBeenCalledWith(connectorId, headerName, headerValue);
     });
 });


### PR DESCRIPTION
This PR moves the authentication controller from MediaController to ConnectorController because it is a general purpose controller applicable to all connectors

## Related tickets

-   [WRS-1](https://support.chili-publish.com/projects/WRS/issues/WRS-1)

## Screenshots
