### PR TITLE
[Fix] Naming and connector page models

### DIFF
--- a/src/controllers/ConnectorController.ts
+++ b/src/controllers/ConnectorController.ts
@@ -39,7 +39,7 @@ export class ConnectorController {
     registerConnector = async (registration: ConnectorRegistration) => {
         const res = await this.#editorAPI;
         return res
-            .mediaConnectorRegisterConnector(JSON.stringify(registration))
+            .registerConnector(JSON.stringify(registration))
             .then((result) => getEditorResponseData<null>(result));
     };
 }

--- a/src/tests/__mocks__/MockEditorAPI.ts
+++ b/src/tests/__mocks__/MockEditorAPI.ts
@@ -115,7 +115,7 @@ export const mockSetConfigValue = jest.fn().mockResolvedValue({ success: true, s
 export const mockGetConfigValue = jest.fn().mockResolvedValue({ success: true, status: 0 });
 export const mockSetFitMode = jest.fn().mockResolvedValue({ success: true, status: 0 });
 export const mockSetVerticalAlignment = jest.fn().mockResolvedValue({ success: true, status: 0 });
-export const mockMediaConnectorRegisterConnector = jest.fn().mockResolvedValue({ success: true, status: 0 });
+export const mockRegisterConnector = jest.fn().mockResolvedValue({ success: true, status: 0 });
 
 const MockEditorAPI = {
     addLayout: mockAddLayout,
@@ -236,7 +236,7 @@ const MockEditorAPI = {
     getConfigValue: mockGetConfigValue,
     setConfigValue: mockSetConfigValue,
     setFitMode: mockSetFitMode,
-    mediaConnectorRegisterConnector: mockMediaConnectorRegisterConnector,
+    registerConnector: mockRegisterConnector,
 };
 
 export default MockEditorAPI;

--- a/src/tests/controllers/ConnectorController.test.ts
+++ b/src/tests/controllers/ConnectorController.test.ts
@@ -33,8 +33,8 @@ describe('Connector methods', () => {
         const headerValue = 'headerValue';
 
         await mockedSDK.connector.registerConnector(registration);
-        expect(mockedSDK.editorAPI.mediaConnectorRegisterConnector).toHaveBeenCalledTimes(1);
-        expect(mockedSDK.editorAPI.mediaConnectorRegisterConnector).toHaveBeenCalledWith(JSON.stringify(registration));
+        expect(mockedSDK.editorAPI.registerConnector).toHaveBeenCalledTimes(1);
+        expect(mockedSDK.editorAPI.registerConnector).toHaveBeenCalledWith(JSON.stringify(registration));
 
         await mockedSDK.connector.authentication.setChiliToken(connectorId, token);
         expect(mockedSDK.editorAPI.connectorAuthenticationSetChiliToken).toHaveBeenCalledTimes(1);

--- a/types/FontConnectorTypes.ts
+++ b/types/FontConnectorTypes.ts
@@ -16,6 +16,7 @@ export type Font = {
 };
 
 export type FontPage = {
+    pageSize: number;
     nextPageToken?: string;
     data: Font[];
 };

--- a/types/MediaConnectorTypes.ts
+++ b/types/MediaConnectorTypes.ts
@@ -14,6 +14,7 @@ export type Media = {
 };
 
 export type MediaPage = {
+    pageSize: number;
     nextPageToken?: string;
     data: Media[];
 };


### PR DESCRIPTION
This PR renames the register connector method and add `pageSize` to the connector page models

## Related tickets

-   [EDT-620](https://support.chili-publish.com/browse/EDT-620)

Can be tested against https://agreeable-mud-052c24203.azurestaticapps.net/?editor=EDT-620 and should be merged in sync with flutter.
