### PR TITLE
[Feature] Add `reorderFrames` and `setFrameZIndex`  to `FrameController`

### DIFF
--- a/src/controllers/FrameController.ts
+++ b/src/controllers/FrameController.ts
@@ -1,7 +1,7 @@
 import type { EditorAPI, Id } from '../../types/CommonTypes';
 import { getCalculatedValue } from '../utils/getCalculatedValue';
 import { getEditorResponseData } from '../utils/EditorResponseData';
-import { FitMode, FrameLayoutType, FrameType, FrameTypeEnum, VerticalAlign } from '../../types/FrameTypes';
+import { FitMode, FrameLayoutType, FrameType, FrameTypeEnum, UpdateZIndexMethod, VerticalAlign } from '../../types/FrameTypes';
 
 /**
  * The FrameController is responsible for all communication regarding Frames.
@@ -130,6 +130,28 @@ export class FrameController {
     selectMultipleFrames = async (frameIds: Id[]) => {
         const res = await this.#editorAPI;
         return res.selectFrames(frameIds).then((result) => getEditorResponseData<null>(result));
+    };
+
+    /**
+     * This method changes the order of frames in the z-index list. 
+     * @param orderIndex The index in the list to move to
+     * @param frameIdsToMove An array of all IDs you want to move to the given index
+     * @returns
+     */
+     reorderFrames = async (orderIndex: number, frameIdsToMove: Id[]) => {
+        const res = await this.#editorAPI;
+        return res.reorderFrames(orderIndex, frameIdsToMove).then((result) => getEditorResponseData<null>(result));
+    };
+
+    /**
+     * This method will update the z-index of a frame.
+     * @param frameId The ID of the frame you want to change the z-index of
+     * @param method The z-index update method to perform
+     * @returns
+     */
+     setFrameZIndex = async (frameId: Id, method: UpdateZIndexMethod) => {
+        const res = await this.#editorAPI;
+        return res.setFrameZIndex(frameId, method).then((result) => getEditorResponseData<null>(result));
     };
 
     /**

--- a/src/tests/__mocks__/MockEditorAPI.ts
+++ b/src/tests/__mocks__/MockEditorAPI.ts
@@ -17,6 +17,8 @@ export const mockSetFrameHeight = jest.fn().mockResolvedValue({ success: true, s
 export const mockSetFrameWidth = jest.fn().mockResolvedValue({ success: true, status: 0 });
 export const mockSetFrameRotation = jest.fn().mockResolvedValue({ success: true, status: 0 });
 export const mockSetFrameVisibility = jest.fn().mockResolvedValue({ success: true, status: 0 });
+export const mockReorderFrames = jest.fn().mockResolvedValue({ success: true, status: 0 });
+export const mockSetFrameZIndex = jest.fn().mockResolvedValue({ success: true, status: 0 });
 export const mockRemoveFrame = jest.fn().mockResolvedValue({ success: true, status: 0 });
 export const mockSetFrameX = jest.fn().mockResolvedValue({ success: true, status: 0 });
 export const mockSetFrameY = jest.fn().mockResolvedValue({ success: true, status: 0 });
@@ -138,6 +140,8 @@ const MockEditorAPI = {
     setFrameWidth: mockSetFrameWidth,
     setFrameVisibility: mockSetFrameVisibility,
     setVerticalAlignment: mockSetVerticalAlignment,
+    reorderFrames: mockReorderFrames,
+    setFrameZIndex: mockSetFrameZIndex,
     removeFrame: mockRemoveFrame,
     setFrameX: mockSetFrameX,
     setFrameY: mockSetFrameY,

--- a/src/tests/controllers/FrameController.test.ts
+++ b/src/tests/controllers/FrameController.test.ts
@@ -1,5 +1,5 @@
 import { Id } from '../../../types/CommonTypes';
-import { FitMode, VerticalAlign } from '../../../types/FrameTypes';
+import { FitMode, UpdateZIndexMethod, VerticalAlign } from '../../../types/FrameTypes';
 import { FrameController } from '../../controllers/FrameController';
 import { mockSelectFrame } from '../__mocks__/FrameProperties';
 import MockEditorAPI from '../__mocks__/MockEditorAPI';
@@ -35,6 +35,8 @@ beforeEach(() => {
     jest.spyOn(mockedFrameProperties, 'setFrameName');
     jest.spyOn(mockedFrameProperties, 'setImageFrameFitMode');
     jest.spyOn(mockedFrameProperties, 'setVerticalAlignment');
+    jest.spyOn(mockedFrameProperties, 'reorderFrames');
+    jest.spyOn(mockedFrameProperties, 'setFrameZIndex');
 
     frameId = mockSelectFrame.frameId;
 });
@@ -135,6 +137,14 @@ describe('FrameProperties', () => {
         mockedFrameProperties.setVerticalAlignment(frameId, VerticalAlign.justify);
         expect(mockedFrameProperties.setVerticalAlignment).toHaveBeenCalledTimes(1);
         expect(mockedFrameProperties.setVerticalAlignment).toHaveBeenCalledWith(frameId, VerticalAlign.justify);
+
+        mockedFrameProperties.reorderFrames(1, [frameId]);
+        expect(mockedFrameProperties.reorderFrames).toHaveBeenCalledTimes(1);
+        expect(mockedFrameProperties.reorderFrames).toHaveBeenCalledWith(1, [frameId]);
+
+        mockedFrameProperties.setFrameZIndex(frameId, UpdateZIndexMethod.sendBackward);
+        expect(mockedFrameProperties.setFrameZIndex).toHaveBeenCalledTimes(1);
+        expect(mockedFrameProperties.setFrameZIndex).toHaveBeenCalledWith(frameId, UpdateZIndexMethod.sendBackward);
     });
 });
 

--- a/types/FrameTypes.ts
+++ b/types/FrameTypes.ts
@@ -114,3 +114,10 @@ export enum FitMode {
     fit = 'fit',
     fill = 'fill',
 }
+
+export enum UpdateZIndexMethod {
+    bringToFront = 'bringToFront',
+    bringToBack = 'bringToBack',
+    sendForward = 'sendForward',
+    sendBackward = 'sendBackward',
+}


### PR DESCRIPTION
This PR adds `reorderFrames` and `setFrameZIndex` methods to `FrameController`.

## Related tickets

-   [EDT-628](https://support.chili-publish.com/browse/EDT-628)

## Screenshots
