### PR TITLE
[Fix] Add resetImageFrameFitMode

### DIFF
--- a/src/controllers/FrameController.ts
+++ b/src/controllers/FrameController.ts
@@ -138,7 +138,7 @@ export class FrameController {
      * @param frameIdsToMove An array of all IDs you want to move to the given index
      * @returns
      */
-     reorderFrames = async (orderIndex: number, frameIdsToMove: Id[]) => {
+    reorderFrames = async (orderIndex: number, frameIdsToMove: Id[]) => {
         const res = await this.#editorAPI;
         return res.reorderFrames(orderIndex, frameIdsToMove).then((result) => getEditorResponseData<null>(result));
     };
@@ -149,7 +149,7 @@ export class FrameController {
      * @param method The z-index update method to perform
      * @returns
      */
-     setFrameZIndex = async (frameId: Id, method: UpdateZIndexMethod) => {
+    setFrameZIndex = async (frameId: Id, method: UpdateZIndexMethod) => {
         const res = await this.#editorAPI;
         return res.setFrameZIndex(frameId, method).then((result) => getEditorResponseData<null>(result));
     };
@@ -316,6 +316,16 @@ export class FrameController {
     };
 
     /**
+     * This method will reset the fitMode property of a specific frame to its original value
+     * @param frameId The ID of the frame that needs to get reset
+     * @returns
+     */
+    resetImageFrameFitMode = async (frameId: Id) => {
+        const res = await this.#editorAPI;
+        return res.resetImageFrameFitMode(frameId).then((result) => getEditorResponseData<null>(result));
+    };
+
+    /**
      * This method will set the visibility property of a specified frame. If set to false the frame will be invisible and vice versa.
      * @param frameId The ID of the frame that needs to get updated
      * @param value True means the frame gets visible, false means the frame gets invisible
@@ -372,7 +382,7 @@ export class FrameController {
      */
     setImageFrameFitMode = async (imageFrameId: Id, fitMode: FitMode) => {
         const res = await this.#editorAPI;
-        return res.setFitMode(imageFrameId, fitMode).then((result) => getEditorResponseData<null>(result));
+        return res.setImageFrameFitMode(imageFrameId, fitMode).then((result) => getEditorResponseData<null>(result));
     };
 
     /**

--- a/src/tests/__mocks__/MockEditorAPI.ts
+++ b/src/tests/__mocks__/MockEditorAPI.ts
@@ -115,9 +115,11 @@ export const mockConnectorAuthenticationSetChiliToken = jest.fn().mockResolvedVa
 export const mockConnectorAuthenticationSetHttpHeader = jest.fn().mockResolvedValue({ success: true, status: 0 });
 export const mockSetConfigValue = jest.fn().mockResolvedValue({ success: true, status: 0 });
 export const mockGetConfigValue = jest.fn().mockResolvedValue({ success: true, status: 0 });
-export const mockSetFitMode = jest.fn().mockResolvedValue({ success: true, status: 0 });
+export const mockSetImageFrameFitMode = jest.fn().mockResolvedValue({ success: true, status: 0 });
 export const mockSetVerticalAlignment = jest.fn().mockResolvedValue({ success: true, status: 0 });
 export const mockRegisterConnector = jest.fn().mockResolvedValue({ success: true, status: 0 });
+export const mockResetImageFrameFitMode = jest.fn().mockResolvedValue({ success: true, status: 0 });
+
 
 const MockEditorAPI = {
     addLayout: mockAddLayout,
@@ -239,7 +241,8 @@ const MockEditorAPI = {
     connectorAuthenticationSetHttpHeader: mockConnectorAuthenticationSetHttpHeader,
     getConfigValue: mockGetConfigValue,
     setConfigValue: mockSetConfigValue,
-    setFitMode: mockSetFitMode,
+    setImageFrameFitMode: mockSetImageFrameFitMode,
+    resetImageFrameFitMode: mockResetImageFrameFitMode,
     registerConnector: mockRegisterConnector,
 };
 

--- a/src/tests/controllers/FrameController.test.ts
+++ b/src/tests/controllers/FrameController.test.ts
@@ -30,6 +30,7 @@ beforeEach(() => {
     jest.spyOn(mockedFrameProperties, 'resetFrameWidth');
     jest.spyOn(mockedFrameProperties, 'resetFrameRotation');
     jest.spyOn(mockedFrameProperties, 'resetFrameSize');
+    jest.spyOn(mockedFrameProperties, 'resetImageFrameFitMode');
     jest.spyOn(mockedFrameProperties, 'selectFrame');
     jest.spyOn(mockedFrameProperties, 'selectMultipleFrames');
     jest.spyOn(mockedFrameProperties, 'setFrameName');
@@ -122,6 +123,9 @@ describe('FrameProperties', () => {
 
         mockedFrameProperties.resetFrameSize('2');
         expect(mockedFrameProperties.resetFrameSize).toHaveBeenCalledTimes(1);
+
+        mockedFrameProperties.resetImageFrameFitMode('2');
+        expect(mockedFrameProperties.resetImageFrameFitMode).toHaveBeenCalledTimes(1);
 
         mockedFrameProperties.selectFrame('2');
         expect(mockedFrameProperties.selectFrame).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
This PR adds the missing `resetImageFrameFitMode` call.

Also renamed the internal `setFitMode` to `setImageFrameFitMode`.

## Related tickets

-   [EDT-646](https://support.chili-publish.com/browse/EDT-646)