### PR TITLE
Add Connector SetMapping / SetOptions

### DIFF
--- a/src/controllers/ConnectorController.ts
+++ b/src/controllers/ConnectorController.ts
@@ -1,5 +1,5 @@
-import { EditorAPI, EditorResponse } from '../../types/CommonTypes';
-import { ConnectorEvent, ConnectorEventType, ConnectorRegistration } from '../../types/ConnectorTypes';
+import { ConnectorOptions, EditorAPI, EditorResponse } from '../../types/CommonTypes';
+import { ConnectorEvent, ConnectorEventType, ConnectorMapping, ConnectorRegistration } from '../../types/ConnectorTypes';
 import { getEditorResponseData } from '../utils/EditorResponseData';
 
 /**
@@ -151,25 +151,34 @@ class ConnectorConfigurator {
         this.#res = res;
     }
 
-    // Future-proofing
-    // setOptions = async (options: ConnectorOptions) => {
-    //     return this.#res
-    //         .setConnectorOptions(this.#connectorId, JSON.stringify(options))
-    //         .then((result) => getEditorResponseData<null>(result));
-    // };
+    /**
+     * Allows to customize the context data a connector can work with. The options data
+     * will be available using the context parameter in the connector implementation code.
+     * @param options object containing key value data to pass to connector context
+     */
+    setOptions = async (options: ConnectorOptions) => {
+        return this.#res
+            .setConnectorOptions(this.#connectorId, JSON.stringify(options))
+            .then((result) => getEditorResponseData<null>(result));
+    };
 
-    // Future-proofing
-    // setMappings = async (mappings: Array<ConnectorMapping>) => {
-    //     const result = await this.#res
-    //         .setConnectorMappings(this.#connectorId, JSON.stringify(mappings));
-    //     return getEditorResponseData<null>(result);
-    // };
+    /**
+     * Allows to map document data (variables, selectedFrame, etc) to connector context data.
+     * By defining the mappings, we can trigger redownload of assets (dynamic asset provider)
+     * or populate filters for the query endpoint. The mapped data will be available using 
+     * the context parameter in the connector implementation code.
+     * @param mappings collection of mappings to set to this connector
+     */
+    setMappings = async (mappings: ConnectorMapping[]) => {
+        const result = await this.#res
+            .setConnectorMappings(this.#connectorId, mappings.map(function (m) { return JSON.stringify(m); }));
+        return getEditorResponseData<null>(result);
+    };
 
     /**
      * This method sets the CHILI GraFx Access Token in the Authentication HTTP header for the 'chili' authentication type.
      * The CHILI Token will be used to authenticate every grafx-media connector http call.
      * Can only be used after a connector has been registered.
-     * @param connectorId unique Id of the media connector
      * @param token token for the CHILI authentication
      */
     setChiliToken = async (token: string) => {
@@ -182,7 +191,6 @@ class ConnectorConfigurator {
      * This method sets the HTTP headers for the 'staticKey' authentication type.
      * These additional headers will be added to all connector http calls.
      * Can only be used after a connector has been registered.
-     * @param connectorId unique Id of the media connector
      * @param headerName name of the header
      * @param headerValue value of the header
      */

--- a/src/index.ts
+++ b/src/index.ts
@@ -97,8 +97,7 @@ export {
 export { ColorType } from '../types/ColorStyleTypes';
 export * from '../types/MediaConnectorTypes';
 export * from '../types/FontConnectorTypes';
-export { MediaType, SortBy, SortOrder, DeprecatedMediaType } from '../types/ConnectorTypes';
-export type { QueryOptions, ConnectorCapabilities, ConnectorRegistration, QueryPage } from '../types/ConnectorTypes';
+export * from '../types/ConnectorTypes';
 
 export { WellKnownConfigurationKeys } from '../types/ConfigurationTypes';
 

--- a/src/tests/__mocks__/MockEditorAPI.ts
+++ b/src/tests/__mocks__/MockEditorAPI.ts
@@ -125,6 +125,8 @@ export const mockUpdateConnectorConfiguration = jest.fn().mockResolvedValue({ su
 export const mockgetConnectorState = jest.fn().mockResolvedValue({ success: true, status: 0 });
 export const mockResetImageFrameFitMode = jest.fn().mockResolvedValue({ success: true, status: 0 });
 export const mockGetPageSnapshot = jest.fn().mockResolvedValue({ success: true, status: 0 });
+export const mockSetConnectorMappings = jest.fn().mockResolvedValue({success: true, status: 0});
+export const mockSetConnectorOptions = jest.fn().mockResolvedValue({success: true, status: 0});
 
 const MockEditorAPI = {
     addLayout: mockAddLayout,
@@ -255,6 +257,8 @@ const MockEditorAPI = {
     updateConnectorConfiguration: mockUpdateConnectorConfiguration,
     getConnectorState: mockgetConnectorState,
     getPageSnapshot: mockGetPageSnapshot,
+    setConnectorMappings: mockSetConnectorMappings,
+    setConnectorOptions:  mockSetConnectorOptions,
 };
 
 export default MockEditorAPI;

--- a/src/tests/controllers/ConnectorController.test.ts
+++ b/src/tests/controllers/ConnectorController.test.ts
@@ -1,7 +1,7 @@
 import { SDK } from '../../index';
 import mockConfig from '../__mocks__/config';
 import { ConnectorController } from '../../controllers/ConnectorController';
-import { ConnectorRegistrationSource } from '../../../types/ConnectorTypes';
+import { ConnectorMapping, ConnectorMappingSource, ConnectorMappingTarget, ConnectorRegistrationSource } from '../../../types/ConnectorTypes';
 import mockChild from '../__mocks__/MockEditorAPI';
 
 let mockedSDK: SDK;
@@ -38,15 +38,16 @@ describe('Connector methods', () => {
         expect(mockedSDK.editorAPI.registerConnector).toHaveBeenCalledWith(JSON.stringify(registration));
 
         await mockedSDK.connector.configure(connectorId, async (configurator) => {
+            configurator.setHttpHeader(headerName, headerValue);
+            configurator.setMappings([new ConnectorMapping(ConnectorMappingTarget.download, "data", ConnectorMappingSource.variable, "Var 1")])
+            configurator.setOptions({'test':'data'});
             configurator.setChiliToken(token);
         });
+
         expect(mockedSDK.editorAPI.connectorAuthenticationSetChiliToken).toHaveBeenCalledTimes(1);
         expect(mockedSDK.editorAPI.connectorAuthenticationSetChiliToken).toHaveBeenCalledWith(connectorId, token);
         expect(mockedSDK.editorAPI.updateConnectorConfiguration).toHaveBeenCalledTimes(1);
-
-        await mockedSDK.connector.configure(connectorId, async (configurator) => {
-            configurator.setHttpHeader(headerName, headerValue);
-        });
+        
         expect(mockedSDK.editorAPI.connectorAuthenticationSetHttpHeader).toHaveBeenCalledTimes(1);
         expect(mockedSDK.editorAPI.connectorAuthenticationSetHttpHeader).toHaveBeenCalledWith(
             connectorId,
@@ -54,16 +55,10 @@ describe('Connector methods', () => {
             headerValue,
         );
 
-        // Future-proofing
-        // const options = { 'hello': 'world' };
-        // await mockedSDK.connector.configure(connectorId, async (configurator) => { configurator.setOptions(options); });
-        // expect(mockedSDK.editorAPI.setConnectorOptions).toHaveBeenCalledTimes(1);
-        // expect(mockedSDK.editorAPI.setConnectorOptions).toHaveBeenCalledWith(connectorId, options);
-
-        // Future-proofing
-        // const mappings = Array<ConnectorMapping>();
-        // await mockedSDK.connector.configure(connectorId, async (configurator) => { configurator.setMappings(mappings); });
-        // expect(mockedSDK.editorAPI.setConnectorOptions).toHaveBeenCalledTimes(1);
-        // expect(mockedSDK.editorAPI.setConnectorOptions).toHaveBeenCalledWith(connectorId, mappings);
+        expect(mockedSDK.editorAPI.setConnectorMappings).toHaveBeenCalledTimes(1);
+        expect(mockedSDK.editorAPI.setConnectorMappings).toHaveBeenCalledWith(connectorId, [JSON.stringify({name:'download.data', value:'var.Var 1'})]);
+        
+        expect(mockedSDK.editorAPI.setConnectorOptions).toHaveBeenCalledTimes(1);
+        expect(mockedSDK.editorAPI.setConnectorOptions).toHaveBeenCalledWith(connectorId, JSON.stringify({'test':'data'}));        
     });
 });

--- a/types/ConnectorTypes.ts
+++ b/types/ConnectorTypes.ts
@@ -46,10 +46,16 @@ export enum ConnectorRegistrationSource {
     url = 'url',
 };
 
-export type ConnectorMapping = {
-    name: string,
-    value: string,
-};
+export class ConnectorMapping {
+    
+    name: string;
+    value: string;
+
+    constructor(mapTo: ConnectorMappingTarget, contextProperty: string, mapFrom: ConnectorMappingSource, sourceValue: string) {
+        this.name = `${mapTo}.${contextProperty}`;
+        this.value = `${mapFrom}.${sourceValue}`;
+    }
+}
 
 export type ConnectorEvent = {
     id: string;
@@ -60,6 +66,15 @@ export type QueryPage<T> = {
     nextPageToken?: string;
     data: T[];
 };
+
+export enum ConnectorMappingTarget {
+    query = 'query',
+    download = 'download'
+}
+
+export enum ConnectorMappingSource {
+    variable = 'var',
+}
 
 export enum ConnectorEventType {
     loading = 'loading',


### PR DESCRIPTION
+ fix exports of Connector typings

This PR fixes some issues we had during development of integration examples. We enabled public API's for the setMapping feature and exposed all Connector Types from the SDK project. 
