### PR TITLE
[Feature] Add `enterTextEditMode`, `exitTextEditMode` on `ExperimentController`

### DIFF
--- a/src/controllers/ExperimentController.ts
+++ b/src/controllers/ExperimentController.ts
@@ -30,4 +30,23 @@ export class ExperimentController {
         const res = await this.#editorAPI;
         return res.insertTextVariable(variableId).then((result) => getEditorResponseData<null>(result));
     };
+
+    /**
+     * This method will enter text editing mode on the provided frame.
+     * @param frameId The ID frame to enter text edit mode on.
+     * @returns
+     */
+    enterTextEditMode = async (frameId: Id) => {
+        const res = await this.#editorAPI;
+        return res.enterTextEditMode(frameId).then((result) => getEditorResponseData<null>(result));
+    };
+
+    /**
+     * This method will exit text editing mode.
+     * @returns
+     */
+    exitTextEditMode = async () => {
+        const res = await this.#editorAPI;
+        return res.exitTextEditMode().then((result) => getEditorResponseData<null>(result));
+    };
 }

--- a/src/tests/__mocks__/MockEditorAPI.ts
+++ b/src/tests/__mocks__/MockEditorAPI.ts
@@ -69,6 +69,8 @@ export const mockSetScrubberPosition = jest.fn().mockResolvedValue({ success: tr
 export const mockSetAnimationDuration = jest.fn().mockResolvedValue({ success: true, status: 0 });
 export const mockResetFrameAnimation = jest.fn().mockResolvedValue({ success: true, status: 0 });
 export const mockInsertTextVariable = jest.fn().mockResolvedValue({ success: true, status: 0 });
+export const mockEnterTextEditMode = jest.fn().mockResolvedValue({ success: true, status: 0 });
+export const mockExitTextEditMode = jest.fn().mockResolvedValue({ success: true, status: 0 });
 export const mockResetAnimation = jest.fn().mockResolvedValue({ success: true, status: 0 });
 export const mockGetPages = jest.fn().mockResolvedValue({ success: true, status: 0 });
 export const mockGetPageById = jest.fn().mockResolvedValue({ success: true, status: 0 });
@@ -132,8 +134,8 @@ export const mockUpdateConnectorConfiguration = jest.fn().mockResolvedValue({ su
 export const mockgetConnectorState = jest.fn().mockResolvedValue({ success: true, status: 0 });
 export const mockResetImageFrameFitMode = jest.fn().mockResolvedValue({ success: true, status: 0 });
 export const mockGetPageSnapshot = jest.fn().mockResolvedValue({ success: true, status: 0 });
-export const mockSetConnectorMappings = jest.fn().mockResolvedValue({success: true, status: 0});
-export const mockSetConnectorOptions = jest.fn().mockResolvedValue({success: true, status: 0});
+export const mockSetConnectorMappings = jest.fn().mockResolvedValue({ success: true, status: 0 });
+export const mockSetConnectorOptions = jest.fn().mockResolvedValue({ success: true, status: 0 });
 
 const MockEditorAPI = {
     addLayout: mockAddLayout,
@@ -176,6 +178,8 @@ const MockEditorAPI = {
     resetFrameRotation: mockResetFrameRotation,
     setFrameAnimation: mockSetFrameAniation,
     insertTextVariable: mockInsertTextVariable,
+    enterTextEditMode: mockEnterTextEditMode,
+    exitTextEditMode: mockExitTextEditMode,
     assignImage: mockAssignImage,
     assignImageFromUrl: mockAssignImageFromUrl,
     getAnimationsOnSelectedLayout: mockGetAnimationsOnSelectedLayout,
@@ -271,7 +275,7 @@ const MockEditorAPI = {
     getConnectorState: mockgetConnectorState,
     getPageSnapshot: mockGetPageSnapshot,
     setConnectorMappings: mockSetConnectorMappings,
-    setConnectorOptions:  mockSetConnectorOptions,
+    setConnectorOptions: mockSetConnectorOptions,
 };
 
 export default MockEditorAPI;

--- a/src/tests/controllers/ExperimentController.test.ts
+++ b/src/tests/controllers/ExperimentController.test.ts
@@ -5,6 +5,8 @@ let mockedExperiments: ExperimentController;
 beforeEach(() => {
     mockedExperiments = new ExperimentController(MockEditorAPI);
     jest.spyOn(mockedExperiments, 'insertTextVariable');
+    jest.spyOn(mockedExperiments, 'enterTextEditMode');
+    jest.spyOn(mockedExperiments, 'exitTextEditMode');
 });
 
 afterAll(() => {
@@ -16,5 +18,12 @@ describe('Experiments', () => {
         mockedExperiments.insertTextVariable('5');
         expect(mockedExperiments.insertTextVariable).toHaveBeenCalledTimes(1);
         expect(mockedExperiments.insertTextVariable).toHaveBeenCalledWith('5');
+
+        mockedExperiments.enterTextEditMode('5');
+        expect(mockedExperiments.enterTextEditMode).toHaveBeenCalledTimes(1);
+        expect(mockedExperiments.enterTextEditMode).toHaveBeenCalledWith('5');
+
+        mockedExperiments.exitTextEditMode();
+        expect(mockedExperiments.exitTextEditMode).toHaveBeenCalledTimes(1);
     });
 });


### PR DESCRIPTION
This PR adds `enterTextEditMode`, `exitTextEditMode` on `ExperimentController`

## Related tickets

-   [EDT-667](https://support.chili-publish.com/browse/EDT-667)

## Screenshots
