### PR TITLE
[Feature] Add `setVariableSource` and `removeVariableSource` SDK methods

### DIFF
--- a/src/controllers/VariableController.ts
+++ b/src/controllers/VariableController.ts
@@ -1,5 +1,5 @@
 import { EditorAPI } from '../../types/CommonTypes';
-import { Variable, VariableMoves, VariableType } from '../../types/VariableTypes';
+import { Variable, VariableMoves, VariableSource, VariableType } from '../../types/VariableTypes';
 import { getEditorResponseData } from '../utils/EditorResponseData';
 
 /**
@@ -183,5 +183,33 @@ export class VariableController {
     setVariableIsReadonly = async (variableId: string, isReadonly: boolean) => {
         const res = await this.#editorAPI;
         return res.setVariableIsReadonly(variableId, isReadonly).then((result) => getEditorResponseData<null>(result));
+    };
+
+    /**
+     * This method sets or removes the variable source
+     * @param variableId The ID of the variable to update
+     * @param src The new variable source
+     */
+    private updateVariableSource = async (variableId: string, src: VariableSource | null) => {
+        const res = await this.#editorAPI;
+        const srcJson = src !== null ? JSON.stringify(src) : null;
+        return res.setVariableSource(variableId, srcJson).then((result) => getEditorResponseData<null>(result));
+    };
+
+    /**
+     * This method sets the variable source
+     * @param variableId The ID of the variable to update
+     * @param src The new variable source
+     */
+    setVariableSource = async (variableId: string, src: VariableSource) => {
+        return this.updateVariableSource(variableId, src);
+    };
+
+    /**
+     * This method removes the variable source
+     * @param variableId The ID of the variable to update
+     */
+    removeVariableSource = async (variableId: string) => {
+        return this.updateVariableSource(variableId, null);
     };
 }

--- a/src/tests/__mocks__/MockEditorAPI.ts
+++ b/src/tests/__mocks__/MockEditorAPI.ts
@@ -58,6 +58,7 @@ export const mockMoveVariables = jest.fn().mockResolvedValue({ success: true, st
 export const mockSetVariableIsHidden = jest.fn().mockResolvedValue({ success: true, status: 0 });
 export const mockSetVariableIsRequired = jest.fn().mockResolvedValue({ success: true, status: 0 });
 export const mockSetVariableIsReadonly = jest.fn().mockResolvedValue({ success: true, status: 0 });
+export const mockSetVariableSource = jest.fn().mockResolvedValue({ success: true, status: 0 });
 export const mockUngroupVariable = jest.fn().mockResolvedValue({ success: true, status: 0 });
 export const mockDuplicateVariable = jest.fn().mockResolvedValue({ success: true, status: 0 });
 export const mockGetVariables = jest.fn().mockResolvedValue({ success: true, status: 0 });
@@ -243,6 +244,7 @@ const MockEditorAPI = {
     setVariableIsHidden: mockSetVariableIsHidden,
     setVariableIsRequired: mockSetVariableIsRequired,
     setVariableIsReadonly: mockSetVariableIsReadonly,
+    setVariableSource: mockSetVariableSource,
     ungroupVariable: mockUngroupVariable,
     getSelectedTool: mockGetSelectedTool,
     setTool: mockSetTool,

--- a/src/tests/controllers/VariableController.test.ts
+++ b/src/tests/controllers/VariableController.test.ts
@@ -1,7 +1,7 @@
 import mockConfig from '../__mocks__/config';
 import { SDK } from '../../index';
 import { VariableController } from '../../controllers/VariableController';
-import { VariableType } from '../../../types/VariableTypes';
+import { ImageVariableSourceType, VariableType } from '../../../types/VariableTypes';
 import mockChild from '../__mocks__/MockEditorAPI';
 
 let mockedSDK: SDK;
@@ -125,5 +125,28 @@ describe('Variable controller', () => {
         await mockedSDK.variable.ungroupVariable('1');
         expect(mockedSDK.editorAPI.ungroupVariable).toHaveBeenCalledTimes(1);
         expect(mockedSDK.editorAPI.ungroupVariable).toHaveBeenCalledWith('1');
+    });
+
+    it('set variable source', async () => {
+        const varId = '1';
+        const src = {
+            url: 'mocked url',
+            sourceType: ImageVariableSourceType.url,
+        };
+        const srcJson = JSON.stringify(src);
+
+        await mockedSDK.variable.setVariableSource(varId, src);
+
+        expect(mockedSDK.editorAPI.setVariableSource).toHaveBeenCalledTimes(1);
+        expect(mockedSDK.editorAPI.setVariableSource).toHaveBeenCalledWith(varId, srcJson);
+    });
+
+    it('remove variable source', async () => {
+        const varId = '1';
+
+        await mockedSDK.variable.removeVariableSource(varId);
+
+        expect(mockedSDK.editorAPI.setVariableSource).toHaveBeenCalledTimes(2);
+        expect(mockedSDK.editorAPI.setVariableSource).toHaveBeenCalledWith(varId, null);
     });
 });

--- a/types/VariableTypes.ts
+++ b/types/VariableTypes.ts
@@ -1,7 +1,8 @@
-enum ImageVariableSourceType {
+export enum ImageVariableSourceType {
     url = 'url',
     mediaConnector = 'mediaConnector',
 }
+
 interface ImageVariable {
     sourceType: ImageVariableSourceType;
 }
@@ -14,6 +15,9 @@ export interface MediaConnectorImageVariable extends ImageVariable {
     connectorId: string;
     assetId: string;
 }
+
+export type VariableSource = UrlImageVariable | MediaConnectorImageVariable;
+
 export enum VariableType {
     shorttext = 'shorttext',
     longtext = 'longtext',
@@ -33,7 +37,7 @@ export type Variable = {
     occurrences?: number;
     value?: string;
     defaultValue?: string;
-    src?: MediaConnectorImageVariable | UrlImageVariable;
+    src?: VariableSource;
 };
 
 export type VariableMoves = {


### PR DESCRIPTION
This PR adds `setVariableSource` and `removeVariableSource` SDK methods on `VariableController`. 

## Related tickets

-   [EDT-688](https://support.chili-publish.com/browse/EDT-688)

## Screenshots
