### PR TITLE
[Fix] Add layoutType for listChanged stream

### DIFF
--- a/src/tests/controllers/SubscriberContoller.test.ts
+++ b/src/tests/controllers/SubscriberContoller.test.ts
@@ -1,4 +1,4 @@
-import { SDK } from '../../index';
+import { LayoutType, SDK } from '../../index';
 import { SubscriberController } from '../../controllers/SubscriberController';
 import mockConfig from '../__mocks__/config';
 import { mockFrameAnimation } from '../__mocks__/animations';
@@ -93,8 +93,11 @@ describe('Subscriber methods', () => {
         mockedSubscribers.onSelectedLayoutIdChanged('new id');
         expect(mockedSDK.config.onSelectedLayoutIdChanged).toHaveBeenCalledWith('new id');
 
-        mockedSubscribers.onLayoutsChanged(JSON.stringify([]));
+        mockedSubscribers.onLayoutsChanged('[{"layoutId":"0","layoutName":"Rectangle","layoutType":"top","parentLayoutId":null,"childLayouts":["2"]}]');
         expect(mockedSDK.config.onLayoutsChanged).toHaveBeenCalledTimes(15);
+        expect(mockedSDK.config.onVariableListChanged).toHaveBeenCalledWith([{ layoutId: "0", layoutName: "Rectangle", layoutType: LayoutType.top, parentLayoutId: null, childLayouts: ["2"] }]
+        );
+
 
         mockedSubscribers.onConnectorStateChanged(JSON.stringify({ id: 'id', type: ConnectorEventType.loaded }));
         expect(mockedSDK.config.onLayoutsChanged).toHaveBeenCalledTimes(16);

--- a/types/LayoutTypes.ts
+++ b/types/LayoutTypes.ts
@@ -50,6 +50,7 @@ export type Layout = {
 export type LayoutListItemType = {
     layoutId: string;
     layoutName: string;
+    layoutType: LayoutType;
     parentLayoutId?: string;
     childLayouts: string[];
 };


### PR DESCRIPTION
This PR adds the layout type to `LayoutListItemType` for the list changed stream to in scope of the `stateChanged` refactoring.

## Related tickets

- [EDT-747](https://support.chili-publish.com/browse/EDT-747)
- [WRS-883](https://support.chili-publish.com/browse/WRS-883)
