### PR TITLE
[Feature] Add `setImageSource` to `FrameController`

### DIFF
--- a/src/controllers/ExperimentController.ts
+++ b/src/controllers/ExperimentController.ts
@@ -1,5 +1,6 @@
 import { EditorAPI, Id } from '../../types/CommonTypes';
 import { getEditorResponseData } from '../utils/EditorResponseData';
+import { ImageSourceTypeEnum, ImageUrlVariableSource } from '../../types/FrameTypes';
 
 /**
  * The ExperimentController contains all SDK functions that are considered for addition,
@@ -28,7 +29,10 @@ export class ExperimentController {
      */
     insertImageVariableToFrame = async (imageFrameId: Id, variableId: string) => {
         const res = await this.#editorAPI;
-        return res.assignImageVariable(imageFrameId, variableId).then((result) => getEditorResponseData<null>(result));
+        const src: ImageUrlVariableSource = { variableId: variableId, sourceType: ImageSourceTypeEnum.urlVariable };
+        return res
+            .setImageSource(imageFrameId, JSON.stringify(src))
+            .then((result) => getEditorResponseData<null>(result));
     };
 
     /**

--- a/src/controllers/ExperimentController.ts
+++ b/src/controllers/ExperimentController.ts
@@ -1,6 +1,5 @@
 import { EditorAPI, Id } from '../../types/CommonTypes';
 import { getEditorResponseData } from '../utils/EditorResponseData';
-import { ImageSourceTypeEnum, ImageUrlVariableSource } from '../../types/FrameTypes';
 
 /**
  * The ExperimentController contains all SDK functions that are considered for addition,
@@ -29,10 +28,7 @@ export class ExperimentController {
      */
     insertImageVariableToFrame = async (imageFrameId: Id, variableId: string) => {
         const res = await this.#editorAPI;
-        const src: ImageUrlVariableSource = { variableId: variableId, sourceType: ImageSourceTypeEnum.urlVariable };
-        return res
-            .setImageSource(imageFrameId, JSON.stringify(src))
-            .then((result) => getEditorResponseData<null>(result));
+        return res.assignImageVariable(imageFrameId, variableId).then((result) => getEditorResponseData<null>(result));
     };
 
     /**

--- a/src/controllers/FrameController.ts
+++ b/src/controllers/FrameController.ts
@@ -10,6 +10,7 @@ import {
     UpdateZIndexMethod,
     VerticalAlign,
 } from '../../types/FrameTypes';
+import { ImageSource } from '../../types/DocumentTypes';
 
 /**
  * The FrameController is responsible for all communication regarding Frames.
@@ -408,6 +409,17 @@ export class FrameController {
     setImageFromUrl = async (imageFrameId: Id, url: string) => {
         const res = await this.#editorAPI;
         return res.assignImageFromUrl(imageFrameId, url).then((result) => getEditorResponseData<null>(result));
+    };
+
+    /**
+     * This method will assign an image from a mediaConnector to the correct ImageFrame
+     * @param imageFrameId The ID of the imageFrame where an image needs to be assigned to
+     * @param source The image source to set to the imageFrame. Can be asset image, url or none
+     * @returns
+     */
+    setImageSource = async (imageFrameId: Id, source?: ImageSource) => {
+        const res = await this.#editorAPI;
+        return res.setImageSource(imageFrameId, source).then((result) => getEditorResponseData<null>(result));
     };
 
     /**

--- a/src/controllers/FrameController.ts
+++ b/src/controllers/FrameController.ts
@@ -6,11 +6,14 @@ import {
     FrameLayoutType,
     FrameType,
     FrameTypeEnum,
+    ImageConnectorSource,
+    ImageFrameSource,
+    ImageSourceTypeEnum,
+    ImageUrlSource,
     ShapeType,
     UpdateZIndexMethod,
     VerticalAlign,
 } from '../../types/FrameTypes';
-import { ImageSource } from '../../types/DocumentTypes';
 
 /**
  * The FrameController is responsible for all communication regarding Frames.
@@ -386,6 +389,26 @@ export class FrameController {
     };
 
     /**
+     * This method sets or removes the image source to the ImageFrame
+     * @param imageFrameId The ID of the imageFrame where an image needs to be assigned to
+     * @param src A new image source
+     * @returns
+     */
+    private updateImageSource = async (imageFrameId: Id, src: ImageFrameSource | null) => {
+        const res = await this.#editorAPI;
+        const srcJson = src !== null ? JSON.stringify(src) : null;
+        return res.setImageSource(imageFrameId, srcJson).then((result) => getEditorResponseData<null>(result));
+    };
+
+    /**
+     * This method removes the image source from the ImageFrame
+     * @param imageFrameId The ID of the imageFrame where an image needs to be removed from
+     */
+    removeImageSource = async (imageFrameId: string) => {
+        return this.updateImageSource(imageFrameId, null);
+    };
+
+    /**
      * This method will assign an image from a mediaConnector to the correct ImageFrame
      * @param imageFrameId The ID of the imageFrame where an image needs to be assigned to
      * @param connectorId Unique Id of the media connector
@@ -393,10 +416,12 @@ export class FrameController {
      * @returns
      */
     setImageFromConnector = async (imageFrameId: Id, connectorId: string, resourceId: string) => {
-        const res = await this.#editorAPI;
-        return res
-            .assignImage(imageFrameId, connectorId, resourceId)
-            .then((result) => getEditorResponseData<null>(result));
+        const src: ImageConnectorSource = {
+            assetId: resourceId,
+            connectorId: connectorId,
+            sourceType: ImageSourceTypeEnum.connector,
+        };
+        return this.updateImageSource(imageFrameId, src);
     };
 
     /**
@@ -407,19 +432,8 @@ export class FrameController {
      * @returns
      */
     setImageFromUrl = async (imageFrameId: Id, url: string) => {
-        const res = await this.#editorAPI;
-        return res.assignImageFromUrl(imageFrameId, url).then((result) => getEditorResponseData<null>(result));
-    };
-
-    /**
-     * This method will assign/reset an image source to the ImageFrame
-     * @param imageFrameId The ID of the imageFrame where an image needs to be assigned to
-     * @param source The image source to set to the imageFrame. Can be asset image, url or none
-     * @returns
-     */
-    setImageSource = async (imageFrameId: Id, source?: ImageSource) => {
-        const res = await this.#editorAPI;
-        return res.setImageSource(imageFrameId, source).then((result) => getEditorResponseData<null>(result));
+        const src: ImageUrlSource = { url: url, sourceType: ImageSourceTypeEnum.url };
+        return this.updateImageSource(imageFrameId, src);
     };
 
     /**

--- a/src/controllers/FrameController.ts
+++ b/src/controllers/FrameController.ts
@@ -412,7 +412,7 @@ export class FrameController {
     };
 
     /**
-     * This method will assign an image from a mediaConnector to the correct ImageFrame
+     * This method will assign/reset an image source to the ImageFrame
      * @param imageFrameId The ID of the imageFrame where an image needs to be assigned to
      * @param source The image source to set to the imageFrame. Can be asset image, url or none
      * @returns

--- a/src/tests/__mocks__/MockEditorAPI.ts
+++ b/src/tests/__mocks__/MockEditorAPI.ts
@@ -26,6 +26,7 @@ export const mockSetFrameX = jest.fn().mockResolvedValue({ success: true, status
 export const mockSetFrameY = jest.fn().mockResolvedValue({ success: true, status: 0 });
 export const mockAssignImage = jest.fn().mockResolvedValue({ success: true, status: 0 });
 export const mockAssignImageFromUrl = jest.fn().mockResolvedValue({ success: true, status: 0 });
+export const mockSetImageSource = jest.fn().mockResolvedValue({ success: true, status: 0 });
 export const mockResetFrame = jest.fn().mockResolvedValue({ success: true, status: 0 });
 export const mockResetFrameX = jest.fn().mockResolvedValue({ success: true, status: 0 });
 export const mockResetFrameY = jest.fn().mockResolvedValue({ success: true, status: 0 });
@@ -206,6 +207,7 @@ const MockEditorAPI = {
     exitTextEditMode: mockExitTextEditMode,
     assignImage: mockAssignImage,
     assignImageFromUrl: mockAssignImageFromUrl,
+    setImageSource: mockSetImageSource,
     getAnimationsOnSelectedLayout: mockGetAnimationsOnSelectedLayout,
     getAnimationByFrameId: mockGetAnimationByFrameId,
     getAnimationsByLayoutId: mockGetAnimationsByLayoutId,

--- a/src/tests/controllers/ExperimentController.test.ts
+++ b/src/tests/controllers/ExperimentController.test.ts
@@ -7,6 +7,7 @@ beforeEach(() => {
     jest.spyOn(mockedExperiments, 'insertTextVariable');
     jest.spyOn(mockedExperiments, 'enterTextEditMode');
     jest.spyOn(mockedExperiments, 'exitTextEditMode');
+    jest.spyOn(mockedExperiments, 'insertImageVariableToFrame');
 });
 
 afterAll(() => {
@@ -25,5 +26,9 @@ describe('Experiments', () => {
 
         mockedExperiments.exitTextEditMode();
         expect(mockedExperiments.exitTextEditMode).toHaveBeenCalledTimes(1);
+
+        mockedExperiments.insertImageVariableToFrame('image-frame-id', 'variable-id');
+        expect(mockedExperiments.insertImageVariableToFrame).toHaveBeenCalledTimes(1);
+        expect(mockedExperiments.insertImageVariableToFrame).toHaveBeenCalledWith('image-frame-id', 'variable-id');
     });
 });

--- a/src/tests/controllers/FrameController.test.ts
+++ b/src/tests/controllers/FrameController.test.ts
@@ -35,7 +35,7 @@ beforeEach(() => {
     jest.spyOn(mockedFrameProperties, 'resetImageFrameFitMode');
     jest.spyOn(mockedFrameProperties, 'setImageFromConnector');
     jest.spyOn(mockedFrameProperties, 'setImageFromUrl');
-    jest.spyOn(mockedFrameProperties, 'setImageSource');
+    jest.spyOn(mockedFrameProperties, 'removeImageSource');
     jest.spyOn(mockedFrameProperties, 'selectFrame');
     jest.spyOn(mockedFrameProperties, 'selectMultipleFrames');
     jest.spyOn(mockedFrameProperties, 'setFrameName');
@@ -209,9 +209,9 @@ describe('FrameProperties', () => {
         expect(mockedFrameProperties.setImageFromUrl).toHaveBeenCalledTimes(1);
         expect(mockedFrameProperties.setImageFromUrl).toHaveBeenCalledWith(frameId, 'image url');
 
-        mockedFrameProperties.setImageSource(frameId, null);
-        expect(mockedFrameProperties.setImageSource).toHaveBeenCalledTimes(1);
-        expect(mockedFrameProperties.setImageSource).toHaveBeenCalledWith(frameId, null);
+        mockedFrameProperties.removeImageSource(frameId);
+        expect(mockedFrameProperties.removeImageSource).toHaveBeenCalledTimes(1);
+        expect(mockedFrameProperties.removeImageSource).toHaveBeenCalledWith(frameId);
 
         mockedFrameProperties.setShapeFrameType(frameId, ShapeType.polygon);
         expect(mockedFrameProperties.setShapeFrameType).toHaveBeenCalledTimes(1);

--- a/src/tests/controllers/FrameController.test.ts
+++ b/src/tests/controllers/FrameController.test.ts
@@ -35,6 +35,7 @@ beforeEach(() => {
     jest.spyOn(mockedFrameProperties, 'resetImageFrameFitMode');
     jest.spyOn(mockedFrameProperties, 'setImageFromConnector');
     jest.spyOn(mockedFrameProperties, 'setImageFromUrl');
+    jest.spyOn(mockedFrameProperties, 'setImageSource');
     jest.spyOn(mockedFrameProperties, 'selectFrame');
     jest.spyOn(mockedFrameProperties, 'selectMultipleFrames');
     jest.spyOn(mockedFrameProperties, 'setFrameName');
@@ -207,6 +208,10 @@ describe('FrameProperties', () => {
         mockedFrameProperties.setImageFromUrl(frameId, 'image url');
         expect(mockedFrameProperties.setImageFromUrl).toHaveBeenCalledTimes(1);
         expect(mockedFrameProperties.setImageFromUrl).toHaveBeenCalledWith(frameId, 'image url');
+
+        mockedFrameProperties.setImageSource(frameId, null);
+        expect(mockedFrameProperties.setImageSource).toHaveBeenCalledTimes(1);
+        expect(mockedFrameProperties.setImageSource).toHaveBeenCalledWith(frameId, null);
 
         mockedFrameProperties.setShapeFrameType(frameId, ShapeType.polygon);
         expect(mockedFrameProperties.setShapeFrameType).toHaveBeenCalledTimes(1);

--- a/types/DocumentTypes.ts
+++ b/types/DocumentTypes.ts
@@ -5,7 +5,7 @@ import { BlendMode, FrameTypeEnum } from './FrameTypes';
 import { LayoutType } from './LayoutTypes';
 import { ParagraphStyle } from './ParagraphStyleTypes';
 import { Variable } from './VariableTypes';
-import {CharacterStyle} from "./CharacterStyleTypes";
+import { CharacterStyle } from './CharacterStyleTypes';
 
 export type DocumentError = { error: Record<string, unknown>; code: number };
 
@@ -68,6 +68,9 @@ export enum ImageFrameSourceType {
     assetProvider = 'assetProvider',
     variable = 'variable',
 }
+
+export type ImageSource = ImageFrameSource | UrlImageFrameSource | null;
+
 export interface ImageFrameSource {
     sourceType: ImageFrameSourceType;
 }

--- a/types/DocumentTypes.ts
+++ b/types/DocumentTypes.ts
@@ -69,8 +69,6 @@ export enum ImageFrameSourceType {
     variable = 'variable',
 }
 
-export type ImageSource = ImageFrameSource | UrlImageFrameSource | null;
-
 export interface ImageFrameSource {
     sourceType: ImageFrameSourceType;
 }

--- a/types/FrameTypes.ts
+++ b/types/FrameTypes.ts
@@ -32,19 +32,29 @@ export type Frame = TextFrame | ImageFrame;
 export type ImageUrlVariableSource = {
     sourceType: ImageSourceTypeEnum.urlVariable;
     variableId: string;
-}
+};
 export type ImageUrlSource = {
     sourceType: ImageSourceTypeEnum.url;
     url: string;
-}
+};
 export type ImageConnectorVariableSource = {
     assetId: string;
     connectorId: string;
     sourceType: ImageSourceTypeEnum.connectorVariable;
     url: string;
-}
+    variableId: string;
+};
+export type ImageConnectorSource = {
+    assetId: string;
+    connectorId: string;
+    sourceType: ImageSourceTypeEnum.connector;
+};
+export type ImageFrameSource =
+    | ImageUrlVariableSource
+    | ImageUrlSource
+    | ImageConnectorVariableSource
+    | ImageConnectorSource;
 // used by new getter methods
-export type ImageFrameSource = ImageUrlVariableSource | ImageUrlSource | ImageConnectorVariableSource;
 export type ImageFrame = {
     frameId: Id;
     frameName: string;
@@ -77,6 +87,7 @@ export enum ImageSourceTypeEnum {
     url = 'url',
     urlVariable = 'urlVariable',
     connectorVariable = 'connectorVariable',
+    connector = 'assetProvider',
 }
 
 export enum FrameTypeEnum {


### PR DESCRIPTION
This PR adds private method `updateImageSource` to FrameController to be able to set or reset the image source for the ImageFrame using the a single method exposed via Editor API

## Related tickets

-   [EDT-693](https://support.chili-publish.com/browse/EDT-693)

## Screenshots
