### PR TITLE
[Feature] Add `detail` method to Connectors

### DIFF
--- a/src/controllers/FontConnectorController.ts
+++ b/src/controllers/FontConnectorController.ts
@@ -52,6 +52,20 @@ export class FontConnectorController {
     };
 
     /**
+     * Returns a single font using a specific FontConnector.
+     * 
+     * The connector needs to list `detail` as a supported capability. 
+     * @param connectorId unique Id of the Font connector
+     * @param fontId unique id of the Font
+     */
+    detail = async (connectorId: string, fontId: string) => {
+        const res = await this.#editorAPI;
+        return res
+            .fontConnectorDetail(connectorId, fontId)
+            .then((result) => getEditorResponseData<Font>(result));
+    };
+
+    /**
      * The combination of a `connectorId` and `FontId` is typically enough for a Font connector to
      * perform the download of this asset. The `download` endpoint is capable of relaying this information to the
      * Font connector instance running in the editor engine.

--- a/src/controllers/FontConnectorController.ts
+++ b/src/controllers/FontConnectorController.ts
@@ -53,16 +53,14 @@ export class FontConnectorController {
 
     /**
      * Returns a single font using a specific FontConnector.
-     * 
-     * The connector needs to list `detail` as a supported capability. 
+     *
+     * The connector needs to list `detail` as a supported capability.
      * @param connectorId unique Id of the Font connector
      * @param fontId unique id of the Font
      */
     detail = async (connectorId: string, fontId: string) => {
         const res = await this.#editorAPI;
-        return res
-            .fontConnectorDetail(connectorId, fontId)
-            .then((result) => getEditorResponseData<Font>(result));
+        return res.fontConnectorDetail(connectorId, fontId).then((result) => getEditorResponseData<Font>(result));
     };
 
     /**

--- a/src/controllers/MediaConnectorController.ts
+++ b/src/controllers/MediaConnectorController.ts
@@ -52,6 +52,20 @@ export class MediaConnectorController {
     };
 
     /**
+     * Returns a single media using a specific MediaConnector.
+     * 
+     * The connector needs to list `detail` as a supported capability. 
+     * @param connectorId unique Id of the Media connector
+     * @param mediaId unique id of the Media
+     */
+    detail = async (connectorId: string, mediaId: string) => {
+        const res = await this.#editorAPI;
+        return res
+            .mediaConnectorDetail(connectorId, mediaId)
+            .then((result) => getEditorResponseData<Media>(result));
+    };
+
+    /**
      * The combination of a `connectorId` and `mediaId` is typically enough for a media connector to
      * perform the download of this asset. The `download` endpoint is capable of relaying this information to the
      * media connector instance running in the editor engine.

--- a/src/controllers/MediaConnectorController.ts
+++ b/src/controllers/MediaConnectorController.ts
@@ -53,16 +53,14 @@ export class MediaConnectorController {
 
     /**
      * Returns a single media using a specific MediaConnector.
-     * 
-     * The connector needs to list `detail` as a supported capability. 
+     *
+     * The connector needs to list `detail` as a supported capability.
      * @param connectorId unique Id of the Media connector
      * @param mediaId unique id of the Media
      */
     detail = async (connectorId: string, mediaId: string) => {
         const res = await this.#editorAPI;
-        return res
-            .mediaConnectorDetail(connectorId, mediaId)
-            .then((result) => getEditorResponseData<Media>(result));
+        return res.mediaConnectorDetail(connectorId, mediaId).then((result) => getEditorResponseData<Media>(result));
     };
 
     /**

--- a/src/tests/__mocks__/MockEditorAPI.ts
+++ b/src/tests/__mocks__/MockEditorAPI.ts
@@ -119,6 +119,7 @@ export const mockAddFont = jest.fn().mockResolvedValue({ success: true, status: 
 export const mockIsFontUsed = jest.fn().mockResolvedValue({ success: true, status: 0 });
 
 export const mockMediaConnectorQuery = jest.fn().mockResolvedValue({ success: true, status: 0 });
+export const mockMediaConnectorDetail = jest.fn().mockResolvedValue({ success: true, status: 0 });
 export const mockMediaConnectorDownload = jest.fn().mockResolvedValue({ success: true, status: 0 });
 export const mockMediaConnectorRemove = jest.fn().mockResolvedValue({ success: true, status: 0 });
 export const mockMediaConnectorCopy = jest.fn().mockResolvedValue({ success: true, status: 0 });
@@ -126,7 +127,9 @@ export const mockMediaConnectorUpload = jest.fn().mockResolvedValue({ success: t
 export const mockMediaConnectorGetCapabilities = jest.fn().mockResolvedValue({ success: true, status: 0 });
 export const mockMediaConnectorGetQueryOptions = jest.fn().mockResolvedValue({ success: true, status: 0 });
 export const mockMediaConnectorGetDownloadOptions = jest.fn().mockResolvedValue({ success: true, status: 0 });
+
 export const mockFontConnectorQuery = jest.fn().mockResolvedValue({ success: true, status: 0 });
+export const mockFontConnectorDetail = jest.fn().mockResolvedValue({ success: true, status: 0 });
 export const mockFontConnectorDownload = jest.fn().mockResolvedValue({ success: true, status: 0 });
 export const mockFontConnectorRemove = jest.fn().mockResolvedValue({ success: true, status: 0 });
 export const mockFontConnectorCopy = jest.fn().mockResolvedValue({ success: true, status: 0 });
@@ -134,6 +137,7 @@ export const mockFontConnectorUpload = jest.fn().mockResolvedValue({ success: tr
 export const mockFontConnectorGetCapabilities = jest.fn().mockResolvedValue({ success: true, status: 0 });
 export const mockFontConnectorGetQueryOptions = jest.fn().mockResolvedValue({ success: true, status: 0 });
 export const mockFontConnectorGetDownloadOptions = jest.fn().mockResolvedValue({ success: true, status: 0 });
+
 export const mockConnectorAuthenticationSetChiliToken = jest.fn().mockResolvedValue({ success: true, status: 0 });
 export const mockConnectorAuthenticationSetHttpHeader = jest.fn().mockResolvedValue({ success: true, status: 0 });
 export const mockSetConfigValue = jest.fn().mockResolvedValue({ success: true, status: 0 });
@@ -296,6 +300,7 @@ const MockEditorAPI = {
     isFontUsed: mockIsFontUsed,
     mediaConnectorCopy: mockMediaConnectorCopy,
     mediaConnectorQuery: mockMediaConnectorQuery,
+    mediaConnectorDetail: mockMediaConnectorDetail,
     mediaConnectorDownload: mockMediaConnectorDownload,
     mediaConnectorRemove: mockMediaConnectorRemove,
     mediaConnectorUpload: mockMediaConnectorUpload,
@@ -303,6 +308,7 @@ const MockEditorAPI = {
     mediaConnectorGetQueryOptions: mockMediaConnectorGetQueryOptions,
     mediaConnectorGetDownloadOptions: mockMediaConnectorGetDownloadOptions,
     fontConnectorCopy: mockFontConnectorCopy,
+    fontConnectorDetail: mockFontConnectorDetail,
     fontConnectorQuery: mockFontConnectorQuery,
     fontConnectorDownload: mockFontConnectorDownload,
     fontConnectorRemove: mockFontConnectorRemove,

--- a/src/tests/controllers/FontConnectorController.test.ts
+++ b/src/tests/controllers/FontConnectorController.test.ts
@@ -12,6 +12,7 @@ beforeEach(() => {
     mockedSDK.editorAPI = mockChild;
     mockedSDK.fontConnector = new FontConnectorController(mockChild);
     jest.spyOn(mockedSDK.fontConnector, 'query');
+    jest.spyOn(mockedSDK.fontConnector, 'detail');
     jest.spyOn(mockedSDK.fontConnector, 'download');
     jest.spyOn(mockedSDK.fontConnector, 'upload');
     jest.spyOn(mockedSDK.fontConnector, 'remove');
@@ -93,5 +94,9 @@ describe('FontConnector methods', () => {
         await mockedSDK.fontConnector.getDownloadOptions(connectorId);
         expect(mockedSDK.editorAPI.fontConnectorGetDownloadOptions).toHaveBeenCalledTimes(1);
         expect(mockedSDK.editorAPI.fontConnectorGetDownloadOptions).toHaveBeenLastCalledWith(connectorId);
+
+        await mockedSDK.fontConnector.detail(connectorId, FontId);
+        expect(mockedSDK.editorAPI.fontConnectorDetail).toHaveBeenCalledTimes(1);
+        expect(mockedSDK.editorAPI.fontConnectorDetail).toHaveBeenLastCalledWith(connectorId, FontId);
     });
 });

--- a/src/tests/controllers/MediaConnectorController.test.ts
+++ b/src/tests/controllers/MediaConnectorController.test.ts
@@ -12,6 +12,7 @@ beforeEach(() => {
     mockedSDK.editorAPI = mockChild;
     mockedSDK.mediaConnector = new MediaConnectorController(mockChild);
     jest.spyOn(mockedSDK.mediaConnector, 'query');
+    jest.spyOn(mockedSDK.mediaConnector, 'detail');
     jest.spyOn(mockedSDK.mediaConnector, 'download');
     jest.spyOn(mockedSDK.mediaConnector, 'upload');
     jest.spyOn(mockedSDK.mediaConnector, 'remove');
@@ -93,5 +94,9 @@ describe('MediaConnector methods', () => {
         await mockedSDK.mediaConnector.getDownloadOptions(connectorId);
         expect(mockedSDK.editorAPI.mediaConnectorGetDownloadOptions).toHaveBeenCalledTimes(1);
         expect(mockedSDK.editorAPI.mediaConnectorGetDownloadOptions).toHaveBeenLastCalledWith(connectorId);
+
+        await mockedSDK.mediaConnector.detail(connectorId, mediaId);
+        expect(mockedSDK.editorAPI.mediaConnectorDetail).toHaveBeenCalledTimes(1);
+        expect(mockedSDK.editorAPI.mediaConnectorDetail).toHaveBeenLastCalledWith(connectorId, mediaId);
     });
 });


### PR DESCRIPTION
This PR adds support for fetching a specific asset from a given connector by id. 

## Related tickets

-   [EDT-745](https://support.chili-publish.com/browse/EDT-745)
