### PR TITLE
[Feature] [EDT-711] Add CornerRadius methods for shapes

### DIFF
--- a/src/controllers/FrameController.ts
+++ b/src/controllers/FrameController.ts
@@ -2,6 +2,7 @@ import type { EditorAPI, Id } from '../types/CommonTypes';
 import { getCalculatedValue } from '../utils/getCalculatedValue';
 import { getEditorResponseData } from '../utils/EditorResponseData';
 import {
+    BlendMode,
     FitMode,
     FrameLayoutType,
     FrameType,
@@ -10,13 +11,12 @@ import {
     ImageFrameSource,
     ImageFrameUrlSource,
     ImageSourceTypeEnum,
-    ShapeType,
     UpdateZIndexMethod,
     VerticalAlign,
-    BlendMode,
 } from '../types/FrameTypes';
 import { ColorUsage } from '../types/ColorStyleTypes';
-import { ShapeProperties } from '../types/DocumentTypes';
+import { ShapeType } from '../types/ShapeTypes';
+import { ShapeController } from './ShapeController';
 
 /**
  * The FrameController is responsible for all communication regarding Frames.
@@ -33,8 +33,14 @@ export class FrameController {
      */
     constructor(editorAPI: EditorAPI) {
         this.#editorAPI = editorAPI;
+        this.shapeController = new ShapeController(this.#editorAPI);
     }
 
+    /**
+     * This variable helps to redirect shapes related methods to newly introduced ShapeController
+     * to avoid any breaking changes
+     */
+    private shapeController: ShapeController;
     /**
      * This method returns the list of frames
      * @returns
@@ -553,27 +559,13 @@ export class FrameController {
     };
 
     /**
-     * This method updates properties of the shape
-     * @param shapeFrameId The ID of the shapeFrame that needs to get updated.
-     * @param properties A property to update
-     * @returns
-     */
-    private setShapeProperties = async (shapeFrameId: Id, properties: ShapeProperties) => {
-        const res = await this.#editorAPI;
-        return res
-            .setShapeProperties(shapeFrameId, JSON.stringify(properties))
-            .then((result) => getEditorResponseData<null>(result));
-    };
-
-    /**
      * This method will set the visibility of the shape fill.
      * @param shapeFrameId The ID of the shapeFrame that needs to get updated.
      * @param enableFill Whether the shape fill is visible.
      * @returns
      */
     setShapeFrameEnableFill = async (shapeFrameId: Id, enableFill: boolean) => {
-        const properties: ShapeProperties = { enableFill: enableFill };
-        return this.setShapeProperties(shapeFrameId, properties);
+        return this.shapeController.setEnableFill(shapeFrameId, enableFill);
     };
 
     /**
@@ -583,8 +575,7 @@ export class FrameController {
      * @returns
      */
     setShapeFrameFillColor = async (shapeFrameId: Id, fillColor: ColorUsage) => {
-        const properties: ShapeProperties = { fillColor: fillColor };
-        return this.setShapeProperties(shapeFrameId, properties);
+        return this.shapeController.setFillColor(shapeFrameId, fillColor);
     };
 
     /**
@@ -594,8 +585,7 @@ export class FrameController {
      * @returns
      */
     setShapeFrameEnableStroke = async (shapeFrameId: Id, enableStroke: boolean) => {
-        const properties: ShapeProperties = { enableStroke: enableStroke };
-        return this.setShapeProperties(shapeFrameId, properties);
+        return this.shapeController.setEnableStroke(shapeFrameId, enableStroke);
     };
 
     /**
@@ -605,8 +595,7 @@ export class FrameController {
      * @returns
      */
     setShapeFrameStrokeColor = async (shapeFrameId: Id, strokeColor: ColorUsage) => {
-        const properties: ShapeProperties = { strokeColor: strokeColor };
-        return this.setShapeProperties(shapeFrameId, properties);
+        return this.shapeController.setStrokeColor(shapeFrameId, strokeColor);
     };
 
     /**
@@ -616,8 +605,7 @@ export class FrameController {
      * @returns
      */
     setShapeFrameStrokeWeight = async (shapeFrameId: Id, strokeWeight: number) => {
-        const properties: ShapeProperties = { strokeWeight: strokeWeight };
-        return this.setShapeProperties(shapeFrameId, properties);
+        return this.shapeController.setStrokeWeight(shapeFrameId, strokeWeight);
     };
 
     /**

--- a/src/controllers/ShapeController.ts
+++ b/src/controllers/ShapeController.ts
@@ -100,7 +100,7 @@ export class ShapeController {
     };
 
     /**
-     * This method updates properties of the rectangle and polygon shapes
+     * This method updates radii of the rectangle and polygon shapes
      * @param shapeFrameId The ID of the shapeFrame that needs to get updated.
      * @param radius A radius object to update a desired corner;
      * @returns

--- a/src/controllers/ShapeController.ts
+++ b/src/controllers/ShapeController.ts
@@ -1,0 +1,169 @@
+import { EditorAPI, Id } from '../types/CommonTypes';
+import { ColorUsage } from '../types/ColorStyleTypes';
+import { CornerRadius, ShapeProperties } from '../types/ShapeTypes';
+import { getEditorResponseData } from '../utils/EditorResponseData';
+
+/**
+ * The ShapeController is responsible for all communication regarding Shapes.
+ * Methods inside this controller can be called by `window.SDK.shape.{method-name}`
+ */
+export class ShapeController {
+    /**
+     * @ignore
+     */
+    #editorAPI: EditorAPI;
+
+    /**
+     * @ignore
+     */
+    constructor(editorAPI: EditorAPI) {
+        this.#editorAPI = editorAPI;
+    }
+
+    /**
+     * This method updates properties of the shape
+     * @param shapeFrameId The ID of the shapeFrame that needs to get updated.
+     * @param properties A property to update
+     * @returns
+     */
+    private setShapeProperties = async (shapeFrameId: Id, properties: ShapeProperties) => {
+        const res = await this.#editorAPI;
+        return res
+            .setShapeProperties(shapeFrameId, JSON.stringify(properties))
+            .then((result) => getEditorResponseData<null>(result));
+    };
+
+    /**
+     * This method will set the visibility of the shape fill.
+     * @param shapeFrameId The ID of the shapeFrame that needs to get updated.
+     * @param enableFill Whether the shape fill is visible.
+     * @returns
+     */
+    setEnableFill = async (shapeFrameId: Id, enableFill: boolean) => {
+        const properties: ShapeProperties = { enableFill: enableFill };
+        return this.setShapeProperties(shapeFrameId, properties);
+    };
+
+    /**
+     * This method will set the shape fill color of a specified shape frame.
+     * @param shapeFrameId The ID of the shapeFrame that needs to get updated.
+     * @param fillColor The new shape fill color that you want to set to the shapeFrame.
+     * @returns
+     */
+    setFillColor = async (shapeFrameId: Id, fillColor: ColorUsage) => {
+        const properties: ShapeProperties = { fillColor: fillColor };
+        return this.setShapeProperties(shapeFrameId, properties);
+    };
+
+    /**
+     * This method will set the visibility of the shape stroke.
+     * @param shapeFrameId The ID of the shapeFrame that needs to get updated.
+     * @param enableStroke Whether the shape stroke is visible.
+     * @returns
+     */
+    setEnableStroke = async (shapeFrameId: Id, enableStroke: boolean) => {
+        const properties: ShapeProperties = { enableStroke: enableStroke };
+        return this.setShapeProperties(shapeFrameId, properties);
+    };
+
+    /**
+     * This method will set the shape stroke color of a specified shape frame.
+     * @param shapeFrameId The ID of the shapeFrame that needs to get updated.
+     * @param strokeColor The new shape stroke color that you want to set to the shapeFrame.
+     * @returns
+     */
+    setStrokeColor = async (shapeFrameId: Id, strokeColor: ColorUsage) => {
+        const properties: ShapeProperties = { strokeColor: strokeColor };
+        return this.setShapeProperties(shapeFrameId, properties);
+    };
+
+    /**
+     * This method will set the shape stroke weight of a specified shape frame.
+     * @param shapeFrameId The ID of the shapeFrame that needs to get updated.
+     * @param strokeWeight The new shape stroke weight that you want to set to the shapeFrame.
+     * @returns
+     */
+    setStrokeWeight = async (shapeFrameId: Id, strokeWeight: number) => {
+        const properties: ShapeProperties = { strokeWeight: strokeWeight };
+        return this.setShapeProperties(shapeFrameId, properties);
+    };
+
+    /**
+     * This method will set the flag to change the way the rectangle shape corners will be changed: all at once or separately.
+     * @param shapeFrameId The ID of the shapeFrame that needs to get updated.
+     * @param allCornersSame The new flag that you want to set to the shapeFrame.
+     * @returns
+     */
+    setFlagAllCornersSame = async (shapeFrameId: Id, allCornersSame: boolean) => {
+        const properties: ShapeProperties = { allCornersSame: allCornersSame };
+        return this.setShapeProperties(shapeFrameId, properties);
+    };
+
+    /**
+     * This method updates properties of the rectangle and polygon shapes
+     * @param shapeFrameId The ID of the shapeFrame that needs to get updated.
+     * @param radius A radius object to update a desired corner;
+     * @returns
+     */
+    private setShapeCorners = async (shapeFrameId: Id, radius: CornerRadius) => {
+        const res = await this.#editorAPI;
+        return res
+            .setShapeCorners(shapeFrameId, JSON.stringify(radius))
+            .then((result) => getEditorResponseData<null>(result));
+    };
+
+    /**
+     * This method will set the radius for all corners of the rectangle and polygon shapes
+     * @param shapeFrameId The ID of the shapeFrame that needs to get updated.
+     * @param radius A radius to update all corners at once;
+     * @returns
+     */
+    setRadiusAll = async (shapeFrameId: Id, radius: number) => {
+        const cornerRadius: CornerRadius = { radiusAll: radius };
+        return this.setShapeCorners(shapeFrameId, cornerRadius);
+    };
+
+    /**
+     * This method will set the radius for the top left corner of the rectangle shape
+     * @param shapeFrameId The ID of the shapeFrame that needs to get updated.
+     * @param radius A radius to update the top left corner;
+     * @returns
+     */
+    setRadiusTopLeft = async (shapeFrameId: Id, radius: number) => {
+        const cornerRadius: CornerRadius = { topLeft: radius };
+        return this.setShapeCorners(shapeFrameId, cornerRadius);
+    };
+
+    /**
+     * This method will set the radius for the bottom left corner of the rectangle shape
+     * @param shapeFrameId The ID of the shapeFrame that needs to get updated.
+     * @param radius A radius to update the bottom left corner;
+     * @returns
+     */
+    setRadiusBottomLeft = async (shapeFrameId: Id, radius: number) => {
+        const cornerRadius: CornerRadius = { bottomLeft: radius };
+        return this.setShapeCorners(shapeFrameId, cornerRadius);
+    };
+
+    /**
+     * This method will set the radius for the top right corner of the rectangle shape
+     * @param shapeFrameId The ID of the shapeFrame that needs to get updated.
+     * @param radius A radius to update the top right corner;
+     * @returns
+     */
+    setRadiusTopRight = async (shapeFrameId: Id, radius: number) => {
+        const cornerRadius: CornerRadius = { topRight: radius };
+        return this.setShapeCorners(shapeFrameId, cornerRadius);
+    };
+
+    /**
+     * This method will set the radius for the bottom right corner of the rectangle shape
+     * @param shapeFrameId The ID of the shapeFrame that needs to get updated.
+     * @param radius A radius to update the bottom right corner;
+     * @returns
+     */
+    setRadiusBottomRight = async (shapeFrameId: Id, radius: number) => {
+        const cornerRadius: CornerRadius = { bottomRight: radius };
+        return this.setShapeCorners(shapeFrameId, cornerRadius);
+    };
+}

--- a/src/controllers/SubscriberController.ts
+++ b/src/controllers/SubscriberController.ts
@@ -224,4 +224,13 @@ export class SubscriberController {
         const callBack = this.config.onPageSizeChanged;
         callBack && callBack(JSON.parse(pageSize));
     };
+
+    /**
+     * Listener on corner radii of rectangle and polygon shapes, this listener will get triggered when any corner radius is changed
+     * @param cornerRadius Stringified object of the CornerRadius
+     */
+    onShapeCornerRadiusChanged = (cornerRadius: string) => {
+        const callBack = this.config.onShapeCornerRadiusChanged;
+        callBack && callBack(JSON.parse(cornerRadius));
+    };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,7 @@ import { CharacterStyleController } from './controllers/CharacterStyleController
 import { CanvasController } from './controllers/CanvasController';
 import { DocumentType } from './types/DocumentTypes';
 import { ActionController } from './controllers/ActionController';
+import { ShapeController } from './controllers/ShapeController';
 
 export { FrameProperyNames, LayoutProperyNames, ToolType, DownloadFormats } from './utils/enums';
 
@@ -66,7 +67,6 @@ export type {
     ImageFrame,
     ShapeFrame,
     ImageFrameSource,
-    ShapeType,
     ImageFrameVariableSource,
     ImageFrameUrlSource,
 } from './types/FrameTypes';
@@ -150,6 +150,7 @@ export class SDK {
     action: ActionController;
     layout: LayoutController;
     frame: FrameController;
+    shape: ShapeController;
     connector: ConnectorController;
     mediaConnector: MediaConnectorController;
     fontConnector: FontConnectorController;
@@ -186,6 +187,7 @@ export class SDK {
         this.action = new ActionController(this.editorAPI);
         this.layout = new LayoutController(this.editorAPI);
         this.frame = new FrameController(this.editorAPI);
+        this.shape = new ShapeController(this.editorAPI);
         this.connector = new ConnectorController(this.editorAPI);
         this.mediaConnector = new MediaConnectorController(this.editorAPI);
         this.fontConnector = new FontConnectorController(this.editorAPI);
@@ -238,6 +240,7 @@ export class SDK {
                 onConnectorEvent: this.subscriber.onConnectorEvent,
                 onZoomChanged: this.subscriber.onZoomChanged,
                 onPageSizeChanged: this.subscriber.onPageSizeChanged,
+                onShapeCornerRadiusChanged: this.subscriber.onShapeCornerRadiusChanged,
             },
             this.setConnection,
             this.config.editorId,
@@ -268,6 +271,7 @@ export class SDK {
         this.font = new FontController(this.editorAPI);
         this.experiment = new ExperimentController(this.editorAPI);
         this.canvas = new CanvasController(this.editorAPI);
+        this.shape = new ShapeController(this.editorAPI);
 
         // as soon as the editor loads, provide it with the SDK version
         // used to make it start. This enables engine compatibility checks

--- a/src/interactions/connector.ts
+++ b/src/interactions/connector.ts
@@ -64,6 +64,7 @@ interface ConfigParameterTypes {
     onConnectorEvent: (state: string) => void;
     onZoomChanged: (scaleFactor: string) => void;
     onPageSizeChanged: (scaleFactor: string) => void;
+    onShapeCornerRadiusChanged: (cornerRadius: string) => void;
 }
 
 const Connect = (
@@ -124,6 +125,7 @@ const Connect = (
                 connectorEvent: params.onConnectorEvent,
                 zoomChanged: params.onZoomChanged,
                 pageSizeChanged: params.onPageSizeChanged,
+                shapeCornerRadiusChanged: params.onShapeCornerRadiusChanged,
             },
         }),
     );

--- a/src/tests/controllers/FrameController.test.ts
+++ b/src/tests/controllers/FrameController.test.ts
@@ -4,7 +4,6 @@ import {
     FitMode,
     FrameTypeEnum,
     ImageSourceTypeEnum,
-    ShapeType,
     UpdateZIndexMethod,
     VerticalAlign,
 } from '../../types/FrameTypes';
@@ -12,7 +11,7 @@ import { FrameController } from '../../controllers/FrameController';
 import { mockSelectFrame } from '../__mocks__/FrameProperties';
 import { mockImageConnectorSource, mockImageUrlSource } from '../__mocks__/MockImageFrameSource';
 import { castToEditorResponse, getEditorResponseData } from '../../utils/EditorResponseData';
-import { ColorType, ColorUsageType } from '../../types/ColorStyleTypes';
+import { ShapeType } from '../../types/ShapeTypes';
 
 let frameId: Id;
 
@@ -351,36 +350,6 @@ describe('FrameController', () => {
         await mockedFrameController.removeImageSource(frameId);
         expect(mockedEditorApi.setImageSource).toHaveBeenCalledTimes(3);
         expect(mockedEditorApi.setImageSource).toHaveBeenCalledWith(frameId, null);
-    });
-    it('Should be possible to set the shape frame enable fill', async () => {
-        await mockedFrameController.setShapeFrameEnableFill(frameId, true);
-        expect(mockedEditorApi.setShapeProperties).toHaveBeenCalledTimes(1);
-        expect(mockedEditorApi.setShapeProperties).toHaveBeenCalledWith(frameId, JSON.stringify({ enableFill: true }));
-    });
-    it('Should be possible to set the shape frame fill color', async () => {
-        const color = { color: { colorType: ColorType.rgb, r: 51, g: 51, b: 51 }, usageType: ColorUsageType.local };
-        await mockedFrameController.setShapeFrameFillColor(frameId, color);
-        expect(mockedEditorApi.setShapeProperties).toHaveBeenCalledTimes(2);
-        expect(mockedEditorApi.setShapeProperties).toHaveBeenCalledWith(frameId, JSON.stringify({ fillColor: color }));
-    });
-    it('Should be possible to set the stroke on a shapeFrame', async () => {
-        await mockedFrameController.setShapeFrameEnableStroke(frameId, true);
-        expect(mockedEditorApi.setShapeProperties).toHaveBeenCalledTimes(3);
-        expect(mockedEditorApi.setShapeProperties).toHaveBeenCalledWith(
-            frameId,
-            JSON.stringify({ enableStroke: true }),
-        );
-    });
-    it('Should be possible to set the stroke color', async () => {
-        const color = { color: { colorType: ColorType.rgb, r: 51, g: 51, b: 51 }, usageType: ColorUsageType.local };
-        await mockedFrameController.setShapeFrameStrokeColor(frameId, color);
-        expect(mockedEditorApi.setShapeProperties).toHaveBeenCalledTimes(4);
-        expect(mockedEditorApi.setShapeProperties).toHaveBeenCalledWith(frameId, JSON.stringify({ fillColor: color }));
-    });
-    it('Should be possible to set the strokeweight', async () => {
-        await mockedFrameController.setShapeFrameStrokeWeight(frameId, 10);
-        expect(mockedEditorApi.setShapeProperties).toHaveBeenCalledTimes(5);
-        expect(mockedEditorApi.setShapeProperties).toHaveBeenCalledWith(frameId, JSON.stringify({ strokeWeight: 10 }));
     });
     it('Should be possible to add blend mode to a specific frame', async () => {
         await mockedFrameController.setFrameBlendMode(frameId, BlendMode.darken);

--- a/src/tests/controllers/ShapeController.test.ts
+++ b/src/tests/controllers/ShapeController.test.ts
@@ -1,0 +1,115 @@
+import { EditorAPI, Id } from '../../types/CommonTypes';
+import { castToEditorResponse, getEditorResponseData } from '../../utils/EditorResponseData';
+import { mockSelectFrame } from '../__mocks__/FrameProperties';
+import { ShapeController } from '../../controllers/ShapeController';
+import { ColorType, ColorUsageType } from '../../types/ColorStyleTypes';
+import { CornerRadius } from '../../types/ShapeTypes';
+
+let frameId: Id;
+
+let mockedShapeController: ShapeController;
+
+const mockedEditorApi: EditorAPI = {
+    setShapeProperties: async () => getEditorResponseData(castToEditorResponse(null)),
+    setShapeCorners: async () => getEditorResponseData(castToEditorResponse(null)),
+};
+
+beforeEach(() => {
+    mockedShapeController = new ShapeController(mockedEditorApi);
+    jest.spyOn(mockedEditorApi, 'setShapeProperties');
+    jest.spyOn(mockedEditorApi, 'setShapeCorners');
+
+    frameId = mockSelectFrame.frameId;
+});
+
+afterAll(() => {
+    jest.restoreAllMocks();
+});
+
+describe('ShapeController', () => {
+    describe('setShapeProperties', () => {
+        it('Should be possible to enable fill', async () => {
+            await mockedShapeController.setEnableFill(frameId, true);
+            expect(mockedEditorApi.setShapeProperties).toHaveBeenCalledTimes(1);
+            expect(mockedEditorApi.setShapeProperties).toHaveBeenCalledWith(
+                frameId,
+                JSON.stringify({ enableFill: true }),
+            );
+        });
+        it('Should be possible to set the shape frame fill color', async () => {
+            const color = { color: { colorType: ColorType.rgb, r: 51, g: 51, b: 51 }, usageType: ColorUsageType.local };
+            await mockedShapeController.setFillColor(frameId, color);
+            expect(mockedEditorApi.setShapeProperties).toHaveBeenCalledTimes(2);
+            expect(mockedEditorApi.setShapeProperties).toHaveBeenCalledWith(
+                frameId,
+                JSON.stringify({ fillColor: color }),
+            );
+        });
+        it('Should be possible to enable stroke', async () => {
+            await mockedShapeController.setEnableStroke(frameId, true);
+            expect(mockedEditorApi.setShapeProperties).toHaveBeenCalledTimes(3);
+            expect(mockedEditorApi.setShapeProperties).toHaveBeenCalledWith(
+                frameId,
+                JSON.stringify({ enableStroke: true }),
+            );
+        });
+        it('Should be possible to set the stroke color', async () => {
+            const color = { color: { colorType: ColorType.rgb, r: 51, g: 51, b: 51 }, usageType: ColorUsageType.local };
+            await mockedShapeController.setStrokeColor(frameId, color);
+            expect(mockedEditorApi.setShapeProperties).toHaveBeenCalledTimes(4);
+            expect(mockedEditorApi.setShapeProperties).toHaveBeenCalledWith(
+                frameId,
+                JSON.stringify({ fillColor: color }),
+            );
+        });
+        it('Should be possible to set the stroke weight', async () => {
+            await mockedShapeController.setStrokeWeight(frameId, 10);
+            expect(mockedEditorApi.setShapeProperties).toHaveBeenCalledTimes(5);
+            expect(mockedEditorApi.setShapeProperties).toHaveBeenCalledWith(
+                frameId,
+                JSON.stringify({ strokeWeight: 10 }),
+            );
+        });
+
+        it('Should be possible to set the flag allCornersSame', async () => {
+            await mockedShapeController.setFlagAllCornersSame(frameId, true);
+            expect(mockedEditorApi.setShapeProperties).toHaveBeenCalledTimes(6);
+            expect(mockedEditorApi.setShapeProperties).toHaveBeenCalledWith(
+                frameId,
+                JSON.stringify({ allCornersSame: true }),
+            );
+        });
+    });
+    describe('setShapeCorners', () => {
+        it('Should be possible to set radius for all corners', async () => {
+            const radius: CornerRadius = { radiusAll: 5 };
+            await mockedShapeController.setRadiusAll(frameId, radius.radiusAll ?? 5);
+            expect(mockedEditorApi.setShapeCorners).toHaveBeenCalledTimes(1);
+            expect(mockedEditorApi.setShapeCorners).toHaveBeenCalledWith(frameId, JSON.stringify(radius));
+        });
+        it('Should be possible to set top left radius', async () => {
+            const radius: CornerRadius = { topLeft: 5 };
+            await mockedShapeController.setRadiusTopLeft(frameId, radius.topLeft ?? 5);
+            expect(mockedEditorApi.setShapeCorners).toHaveBeenCalledTimes(2);
+            expect(mockedEditorApi.setShapeCorners).toHaveBeenCalledWith(frameId, JSON.stringify(radius));
+        });
+        it('Should be possible to set bottom left radius', async () => {
+            const radius: CornerRadius = { bottomLeft: 5 };
+            await mockedShapeController.setRadiusBottomLeft(frameId, radius.bottomLeft ?? 5);
+            expect(mockedEditorApi.setShapeCorners).toHaveBeenCalledTimes(3);
+            expect(mockedEditorApi.setShapeCorners).toHaveBeenCalledWith(frameId, JSON.stringify(radius));
+        });
+        it('Should be possible to set top right radius', async () => {
+            const radius: CornerRadius = { topRight: 5 };
+            await mockedShapeController.setRadiusTopRight(frameId, radius.topRight ?? 5);
+            expect(mockedEditorApi.setShapeCorners).toHaveBeenCalledTimes(4);
+            expect(mockedEditorApi.setShapeCorners).toHaveBeenCalledWith(frameId, JSON.stringify(radius));
+        });
+        it('Should be possible to set bottom right radius', async () => {
+            const radius: CornerRadius = { bottomRight: 5 };
+            await mockedShapeController.setRadiusBottomRight(frameId, radius.bottomRight ?? 5);
+            expect(mockedEditorApi.setShapeCorners).toHaveBeenCalledTimes(5);
+            expect(mockedEditorApi.setShapeCorners).toHaveBeenCalledWith(frameId, JSON.stringify(radius));
+        });
+    });
+});

--- a/src/tests/controllers/SubscriberContoller.test.ts
+++ b/src/tests/controllers/SubscriberContoller.test.ts
@@ -8,8 +8,9 @@ import { VariableType } from '../../types/VariableTypes';
 import { ToolType } from '../../utils/enums';
 import { ConnectorStateType } from '../../types/ConnectorTypes';
 import type { PageSize } from '../../types/PageTypes';
+import { CornerRadius } from '../../types/ShapeTypes';
 import { EditorAPI } from '../../types/CommonTypes';
-import { getEditorResponseData, castToEditorResponse } from '../../utils/EditorResponseData';
+import { castToEditorResponse, getEditorResponseData } from '../../utils/EditorResponseData';
 
 let mockedAnimation: FrameAnimationType;
 let mockedSubscriberController: SubscriberController;
@@ -39,6 +40,7 @@ const mockEditorApi: EditorAPI = {
     onPageSizeChanged: async () => getEditorResponseData(castToEditorResponse(null)),
     onScrubberPositionChanged: async () => getEditorResponseData(castToEditorResponse(null)),
     onUndoStackStateChanged: async () => getEditorResponseData(castToEditorResponse(null)),
+    onShapeCornerRadiusChanged: async () => getEditorResponseData(castToEditorResponse(null)),
 };
 
 beforeEach(() => {
@@ -69,6 +71,7 @@ beforeEach(() => {
     jest.spyOn(mockEditorApi, 'onPageSizeChanged');
     jest.spyOn(mockEditorApi, 'onScrubberPositionChanged');
     jest.spyOn(mockEditorApi, 'onUndoStackStateChanged');
+    jest.spyOn(mockEditorApi, 'onShapeCornerRadiusChanged');
 });
 
 afterEach(() => {
@@ -190,5 +193,13 @@ describe('SubscriberController', () => {
     it('Should call trigger the UndoStateChanges subscriber when triggered', async () => {
         await mockedSubscriberController.onUndoStateChanged(JSON.stringify({ canRedo: false, canUndo: true }));
         expect(mockEditorApi.onUndoStackStateChanged).toHaveBeenCalledTimes(1);
+    });
+
+    it('should be possible to subscribe to onShapeCornerRadiusChanged', async () => {
+        const cornerRadius: CornerRadius = { radiusAll: 5 };
+        await mockedSubscriberController.onShapeCornerRadiusChanged(JSON.stringify(cornerRadius));
+
+        expect(mockEditorApi.onShapeCornerRadiusChanged).toHaveBeenCalledTimes(1);
+        expect(mockEditorApi.onShapeCornerRadiusChanged).toHaveBeenCalledWith(cornerRadius);
     });
 });

--- a/src/types/CommonTypes.ts
+++ b/src/types/CommonTypes.ts
@@ -13,6 +13,7 @@ import { CharacterStyle } from './CharacterStyleTypes';
 import { ConnectorEvent } from './ConnectorTypes';
 import { PageSize } from './PageTypes';
 import { SelectedTextStyle } from './TextStyleTypes';
+import { CornerRadius } from './ShapeTypes';
 
 export type Id = string;
 
@@ -43,6 +44,7 @@ export type ConfigType = {
     onConnectorEvent?: (event: ConnectorEvent) => void;
     onZoomChanged?: (scaleFactor: number) => void;
     onPageSizeChanged?: (pageSize: PageSize) => void;
+    onShapeCornerRadiusChanged?: (cornerRadius: CornerRadius) => void;
 };
 
 export interface EditorResponse<T> {

--- a/src/types/DocumentTypes.ts
+++ b/src/types/DocumentTypes.ts
@@ -1,12 +1,13 @@
 import { BasicAnimationsEmphasisType, BasicAnimationsIntroType, BasicAnimationsOutroType } from './AnimationTypes';
-import { ColorUsage, DocumentColor } from './ColorStyleTypes';
+import { DocumentColor } from './ColorStyleTypes';
 import { Id } from './CommonTypes';
-import { BlendMode, FrameTypeEnum, ShapeType } from './FrameTypes';
+import { BlendMode, FrameTypeEnum } from './FrameTypes';
 import { LayoutType } from './LayoutTypes';
 import { ParagraphStyle } from './ParagraphStyleTypes';
 import { Variable } from './VariableTypes';
 import { CharacterStyle } from './CharacterStyleTypes';
 import { DocumentAction } from './ActionTypes';
+import { ShapeProperties, ShapeType } from './ShapeTypes';
 
 export type DocumentError = { error: Record<string, unknown>; code: number };
 
@@ -53,14 +54,6 @@ export interface ImageFrame extends DocumentFrame {
 export interface ShapeFrame extends DocumentFrame {
     shapeType: ShapeType;
     shapeProperties: ShapeProperties;
-}
-
-export interface ShapeProperties {
-    enableFill?: boolean;
-    fillColor?: ColorUsage;
-    enableStroke?: boolean;
-    strokeColor?: ColorUsage;
-    strokeWeight?: number;
 }
 
 export interface TextFrame extends DocumentFrame {

--- a/src/types/FrameTypes.ts
+++ b/src/types/FrameTypes.ts
@@ -1,6 +1,7 @@
 // FramePropertiesDto
 import { ColorUsage } from './ColorStyleTypes';
 import { Id, PropertyState } from './CommonTypes';
+import { ShapeType } from './ShapeTypes';
 
 export type FrameLayoutType = {
     frameId: Id;
@@ -72,6 +73,7 @@ export type ShapeFrame = {
         enableStroke: boolean;
         strokeWeight: number;
         strokeColor: ColorUsage;
+        allCornersSame: boolean;
     };
     src: {
         shapeType: ShapeType;
@@ -160,10 +162,4 @@ export enum UpdateZIndexMethod {
     sendToBack = 'sendToBack',
     bringForward = 'bringForward',
     sendBackward = 'sendBackward',
-}
-
-export enum ShapeType {
-    ellipse = 'ellipse',
-    rectangle = 'rectangle',
-    polygon = 'polygon',
 }

--- a/src/types/ShapeTypes.ts
+++ b/src/types/ShapeTypes.ts
@@ -1,0 +1,30 @@
+import { ColorUsage } from './ColorStyleTypes';
+
+export enum ShapeType {
+    ellipse = 'ellipse',
+    rectangle = 'rectangle',
+    polygon = 'polygon',
+}
+
+export interface ShapeProperties {
+    enableFill?: boolean;
+    fillColor?: ColorUsage;
+    enableStroke?: boolean;
+    strokeColor?: ColorUsage;
+    strokeWeight?: number;
+    allCornersSame?: boolean;
+}
+
+export interface CornerRadius {
+    radiusAll?: number;
+    topLeft?: number;
+    bottomLeft?: number;
+    topRight?: number;
+    bottomRight?: number;
+}
+
+export enum CornerRadiusType {
+    all = 'all',
+    only = 'only',
+    none = 'none',
+}


### PR DESCRIPTION
This PR:
- added new methods to set corner radii for shapes
- added new types related to corner radii
- added new subscriber method to listen corner radii changes
- shape related methods moved from `FrameController` to the new `ShapeController`, BUT the FrameController ones remain functional

## Related tickets

-   [EDT-711](https://support.chili-publish.com/browse/EDT-711)
